### PR TITLE
Client generation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -261,6 +261,13 @@
             <artifactId>jackson-jaxrs-xml-provider</artifactId>
             <version>2.10.1</version>
         </dependency>
+        <!-- https://mvnrepository.com/artifact/org.openapitools/jackson-databind-nullable
+             Used for OpenAPI client generation -->
+        <dependency>
+            <groupId>org.openapitools</groupId>
+            <artifactId>jackson-databind-nullable</artifactId>
+            <version>0.2.2</version>
+        </dependency>
 
 
 
@@ -402,6 +409,20 @@
             <type>pom</type>
             <scope>runtime</scope>
         </dependency>-->
+        <!-- To get client generation to work -->
+        <!-- https://mvnrepository.com/artifact/org.openapitools/openapi-generator -->
+        <dependency>
+            <groupId>org.openapitools</groupId>
+            <artifactId>openapi-generator</artifactId>
+            <version>5.3.0</version>
+            <exclusions>
+                <exclusion>
+                    <!-- The slf4j-simple logs to stderr and stdout, ignoring logback.xml -->
+                    <artifactId>slf4j-simple</artifactId>
+                    <groupId>org.slf4j</groupId>
+                </exclusion>
+            </exclusions>
+        </dependency>
 
 
         <!-- Logging dependencies -->
@@ -658,8 +679,58 @@
                             </configOptions>
                         </configuration>
                     </execution>
+                    <!-- Client for the backend -->
+                    <execution>
+                        <id>Generate client for JAR package and use by other services</id>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                        <configuration>
+                            <inputSpec>${project.build.outputDirectory}/ds-license-openapi_v1.yaml</inputSpec>
+                            <ignoreFileOverride>${project.basedir}/.openapi-codegen-ignore-api</ignoreFileOverride>
+                            <generatorName>java</generatorName>
+                            <library>native</library>
+
+                            <!-- Do not generate doc or tests for this client, we will handle this ourselves-->
+                            <generateApis>true</generateApis>
+                            <generateApiTests>false</generateApiTests>
+                            <generateApiDocumentation>false</generateApiDocumentation>
+                            <generateModels>false</generateModels>
+                            <generateModelTests>false</generateModelTests>
+                            <generateModelDocumentation>false</generateModelDocumentation>
+
+                            <!-- Ensure ONLY the ApiClient and supporting classes are created, not the gradle mess-->
+                            <generateSupportingFiles>true</generateSupportingFiles>
+                            <supportingFilesToGenerate>ApiClient.java,ApiException.java,Configuration.java,Pair.java</supportingFilesToGenerate>
+
+                            <!-- Do NOT use the customised templates as they are only for the webservice part, not the client-->
+                            <!-- Hacked by Asger by setting to an existing folder without templates -->
+                            <templateDirectory>src/main/</templateDirectory>
+
+                            <configOptions>
+                                <apiPackage>${project.package}.client.v1</apiPackage>
+                                <modelPackage>${project.package}.model.v1</modelPackage>
+                                <invokerPackage>${project.package}.invoker.v1</invokerPackage>
+                                <sourceFolder>target/generated-sources</sourceFolder>
+                                <implFolder>target/generated-sources</implFolder>
+                            </configOptions>
+                        </configuration>
+                    </execution>
 
                 </executions>
+            </plugin>
+
+            <!-- The generated classes for the OpenAPI client are problematic. Disable checking of those for now -->
+            <plugin>
+                <groupId>de.thetaphi</groupId>
+                <artifactId>forbiddenapis</artifactId>
+                <!-- No version or configuration here as it inherits from parent pom -->
+                <configuration>
+                    <excludes>
+                        <exclude>**/DsLicenseApi.class</exclude>
+                        <exclude>**/ServiceApi.class</exclude>
+                    </excludes>
+                </configuration>
             </plugin>
 
             <plugin>
@@ -673,7 +744,7 @@
                         </manifest>
                     </archive>
                     
-                    <!-- Will generate a jar file with classes-->
+                    <!-- Generate a JAR with client classes and openapi-YAML for easy use by other services -->
                     <attachClasses>true</attachClasses>
 
                     <!--Enable maven filtering for the web.xml-->

--- a/src/test/java/dk/kb/license/ClientInstantiationTest.java
+++ b/src/test/java/dk/kb/license/ClientInstantiationTest.java
@@ -1,0 +1,69 @@
+/*
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package dk.kb.license;
+
+import dk.kb.license.client.v1.DsLicenseApi;
+import dk.kb.license.invoker.v1.ApiClient;
+import dk.kb.license.invoker.v1.Configuration;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.URI;
+
+/**
+ * How to use the ds-license client demonstration (and instantiation unit test).
+ *
+ * When used from another project, add pomx.ml dependency with
+ * <pre>
+ * <dependency>
+ *     <groupId>dk.kb.license</groupId>
+ *     <artifactId>ds-license</artifactId>
+ *     <version>1.0-SNAPSHOT</version>
+ *     <type>jar</type>
+ *     <classifier>classes</classifier>
+ *     <exclusions>
+ *         <exclusion>
+ *             <groupId>*</groupId>
+ *             <artifactId>*</artifactId>
+ *         </exclusion>
+ *     </exclusions>
+ * </dependency>
+ * </pre>
+ * During development, a SNAPSHOT dependency can be installed locally by running
+ * {@code mvn install} in the {@code ds-license} checkout.
+ */
+public class ClientInstantiationTest {
+    private static final Logger log = LoggerFactory.getLogger(ClientInstantiationTest.class);
+
+    // We cannot test usage as that would require a running instance of ds-license to connect to
+    @Test
+    public void testInstantiation() {
+        String backendURIString = "htp://example.com/ds-license/v1";
+        log.debug("Creating inactive client for ds-license with URI '{}'", backendURIString);
+
+        URI serviceURI = URI.create(backendURIString);
+
+        // No mechanism for just providing the full URI. We have to deconstruct it
+        ApiClient client = Configuration.getDefaultApiClient();
+        client.setScheme(serviceURI.getScheme());
+        client.setHost(serviceURI.getHost());
+        client.setPort(serviceURI.getPort());
+        client.setBasePath(serviceURI.getRawPath());
+
+        // Note that the import is dk.kb.license.client.v1.DsLicenseApi
+        new DsLicenseApi(client);
+    }
+}


### PR DESCRIPTION
This pull request adds generation of a JAR with a ds-client to the `package` phase of Maven. The client can be used from other project using a simple import:
```
 <dependency>
     <groupId>dk.kb.license</groupId>
     <artifactId>ds-license</artifactId>
     <version>1.0-SNAPSHOT</version>
     <type>jar</type>
     <classifier>classes</classifier>
     <exclusions>
         <exclusion>
             <groupId>*</groupId>
             <artifactId>*</artifactId>
         </exclusion>
     </exclusions>
 </dependency>
```
See `ClientInstantiationTest.java` for sample of client instantiation.