### PR TITLE
Disc 92 license return non access ids

### DIFF
--- a/conf/ds-license.logback.xml
+++ b/conf/ds-license.logback.xml
@@ -20,7 +20,7 @@
     </appender>
 
     <root level="INFO">
-      <appender-ref ref="STDOUT" />
+      <appender-ref ref="FILE" />
     </root>
     <logger name="dk.kb" level="DEBUG" />
  

--- a/docs/CheckAccessForIdsOutputDto.md
+++ b/docs/CheckAccessForIdsOutputDto.md
@@ -9,6 +9,7 @@ Name | Type | Description | Notes
 **presentationType** | **String** |  |  [optional]
 **query** | **String** | Solr query |  [optional]
 **accessIds** | **List&lt;String&gt;** |  |  [optional]
+**nonAccessIds** | **List&lt;String&gt;** |  |  [optional]
 
 
 

--- a/docs/CheckAccessForIdsOutputDto.md
+++ b/docs/CheckAccessForIdsOutputDto.md
@@ -10,6 +10,7 @@ Name | Type | Description | Notes
 **query** | **String** | Solr query |  [optional]
 **accessIds** | **List&lt;String&gt;** |  |  [optional]
 **nonAccessIds** | **List&lt;String&gt;** |  |  [optional]
+**nonExistingIds** | **List&lt;String&gt;** |  |  [optional]
 
 
 

--- a/docs/DsLicenseApi.md
+++ b/docs/DsLicenseApi.md
@@ -132,7 +132,7 @@ No authorization required
 ### HTTP response details
 | Status code | Description | Response headers |
 |-------------|-------------|------------------|
-**200** | Returns the IDs that has not been filtered by the query. Also return the Solr filter query that was used. |  -  |
+**200** | Returns the IDs that has not been filtered by the query. Also return the Solr filter query that was used. IDs that exists but with no access will be return in nonAccessId field |  -  |
 
 <a name="getGreeting"></a>
 # **getGreeting**

--- a/src/main/java/dk/kb/license/api/v1/impl/DsLicenseApiServiceImpl.java
+++ b/src/main/java/dk/kb/license/api/v1/impl/DsLicenseApiServiceImpl.java
@@ -179,9 +179,8 @@ public class DsLicenseApiServiceImpl extends ImplBase implements DsLicenseApi {
 
 	public  GetUsersFilterQueryOutputDto getUserLicenseQuery(@NotNull GetUserQueryInputDto input) {
 		log.debug("getUserLicenseQuery(...) called with call details: {}", getCallDetails());
-
-		//MonitorCache.registerNewRestMethodCall("getUserLicenseQuery");
-		log.info("getUserLicenseQuery called");
+		
+		//MonitorCache.registerNewRestMethodCall("getUserLicenseQuery");		
 		try {
 			GetUserQueryOutputDto output = LicenseValidator.getUserQuery(input);   
 
@@ -193,7 +192,6 @@ public class DsLicenseApiServiceImpl extends ImplBase implements DsLicenseApi {
 
 			GetUsersFilterQueryOutputDto filterQuery= new GetUsersFilterQueryOutputDto();
 			filterQuery.setFilterQuery(output.getQuery());
-
 			return filterQuery;
 		} catch (Exception e) {
 			throw handleException(e);

--- a/src/main/java/dk/kb/license/api/v1/impl/DsLicenseApiServiceImpl.java
+++ b/src/main/java/dk/kb/license/api/v1/impl/DsLicenseApiServiceImpl.java
@@ -2,6 +2,7 @@ package dk.kb.license.api.v1.impl;
 
 
 import dk.kb.license.api.v1.DsLicenseApi;
+import dk.kb.license.config.ServiceConfig;
 import dk.kb.license.model.v1.CheckAccessForIdsInputDto;
 import dk.kb.license.model.v1.CheckAccessForIdsOutputDto;
 import dk.kb.license.model.v1.GetUserGroupsAndLicensesInputDto;
@@ -87,7 +88,7 @@ public class DsLicenseApiServiceImpl extends ImplBase implements DsLicenseApi {
 		}
 
 		try {      
-			CheckAccessForIdsOutputDto output = LicenseValidator.checkAccessForIds(input);      
+			CheckAccessForIdsOutputDto output = LicenseValidator.checkAccessForIds(input,ServiceConfig.SOLR_FILTER_ID_FIELD);      
 			return output;
 		} catch (Exception e) {
 			log.error("Error in checkAccessForIds:",e);
@@ -113,8 +114,8 @@ public class DsLicenseApiServiceImpl extends ImplBase implements DsLicenseApi {
             return output;
         }
 
-        try {      
-            CheckAccessForIdsOutputDto output = LicenseValidator.checkAccessForResourceIds(input);      
+        try {          
+            CheckAccessForIdsOutputDto output = LicenseValidator.checkAccessForIds(input,ServiceConfig.SOLR_FILTER_RESOURCE_ID_FIELD);      
             return output;
         } catch (Exception e) {
             log.error("Error in checkAccessForResourceIds:",e);

--- a/src/main/java/dk/kb/license/servlets/ConfigurationServlet.java
+++ b/src/main/java/dk/kb/license/servlets/ConfigurationServlet.java
@@ -15,6 +15,7 @@ import javax.servlet.http.HttpServletResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import dk.kb.license.config.ServiceConfig;
 import dk.kb.license.facade.LicenseModuleFacade;
 import dk.kb.license.model.v1.CheckAccessForIdsInputDto;
 import dk.kb.license.model.v1.CheckAccessForIdsOutputDto;
@@ -31,399 +32,398 @@ import dk.kb.license.validation.LicenseValidator;
 
 public class ConfigurationServlet extends HttpServlet {
 
-	private static final long serialVersionUID = 1L;
-	private static final Logger log = LoggerFactory.getLogger(ConfigurationServlet.class);
+    private static final long serialVersionUID = 1L;
+    private static final Logger log = LoggerFactory.getLogger(ConfigurationServlet.class);
 
-	public void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+    public void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
 
-		response.setContentType("text/html; charset=UTF-8");
-		request.setCharacterEncoding("UTF-8");
+        response.setContentType("text/html; charset=UTF-8");
+        request.setCharacterEncoding("UTF-8");
 
-		String event = request.getParameter("event");
-		log.info("New event for ConfigurationServlet:" + event);
-
-
-
-		try {
-			// tab 0 is list licenses
-
-			if ("save_presentationtype".equals(event)) {
-				request.setAttribute("tab", "1");
-				String key = request.getParameter("key_presentationtype");
-				String value = request.getParameter("value_presentationtype");
-				String value_en = request.getParameter("value_en_presentationtype");
-				log.debug("Saving new presentationtype:" + key);
-				LicenseModuleFacade.persistLicensePresentationType(key,value,value_en);
-			}
-			else if ("save_grouptype".equals(event)) {
-				request.setAttribute("tab", "2");
-				String key = request.getParameter("key_grouptype");
-				String value_dk = request.getParameter("value_grouptype");
-				String value_en = request.getParameter("value_en_grouptype");
-				String description = request.getParameter("value_groupdescription");
-				String description_en = request.getParameter("value_en_groupdescription");
-				String query = request.getParameter("value_groupquery");
-				String typeStr = request.getParameter("type");
-					
-				boolean isKlausulering = false;
-				
-				if ("klausulering".equals(typeStr)) { 
-				    isKlausulering = true;
-				}
-				log.debug("Saving new grouptype:" + key +" klausulering:"+isKlausulering);
-				LicenseModuleFacade.persistLicenseGroupType(key,value_dk,value_en,description,description_en,query, isKlausulering);
-
-			} else if ("save_attributetype".equals(event)) {
-
-				request.setAttribute("tab", "3");
-				String value = request.getParameter("value_attributetype");
-				log.debug("Saving new attributetype:" + value);
-				LicenseModuleFacade.persistAttributeType(value);
-
-			} else if ("validate".equals(event)) {
-				log.debug("validate called");
-				request.setAttribute("tab", "4");
-				String validation_attribute_values = request.getParameter("validation_attribute_values");				                                                           		
-				String validation_groups = request.getParameter("validation_groups");
-				String validation_presentationtype = request.getParameter("validation_presentationtype");
-
-				request.setAttribute("validation_attribute_values", validation_attribute_values);
-				request.setAttribute("validation_groups", validation_groups);
-				request.setAttribute("validation_presentationtype", validation_presentationtype);
+        String event = request.getParameter("event");
+        log.info("New event for ConfigurationServlet:" + event);
 
 
-				String result = decomposeValidateAccess(validation_attribute_values,validation_groups,validation_presentationtype);
-				request.setAttribute("validation_result", result);		
-			}
-			else if ("validateQuery".equals(event)) {
-				log.debug("validateQuery called");
-				request.setAttribute("tab", "5");
-				String validationQuery_attribute_values = request.getParameter("validationQuery_attribute_values");				                                                           		
-				String validationQuery_presentationtype = request.getParameter("validationQuery_presentationtype");
+        try {
+            // tab 0 is list licenses
 
-				request.setAttribute("validationQuery_attribute_values", validationQuery_attribute_values);
-				request.setAttribute("validationQuery_presentationtype", validationQuery_presentationtype);
+            if ("save_presentationtype".equals(event)) {
+                request.setAttribute("tab", "1");
+                String key = request.getParameter("key_presentationtype");
+                String value = request.getParameter("value_presentationtype");
+                String value_en = request.getParameter("value_en_presentationtype");
+                log.debug("Saving new presentationtype:" + key);
+                LicenseModuleFacade.persistLicensePresentationType(key,value,value_en);
+            }
+            else if ("save_grouptype".equals(event)) {
+                request.setAttribute("tab", "2");
+                String key = request.getParameter("key_grouptype");
+                String value_dk = request.getParameter("value_grouptype");
+                String value_en = request.getParameter("value_en_grouptype");
+                String description = request.getParameter("value_groupdescription");
+                String description_en = request.getParameter("value_en_groupdescription");
+                String query = request.getParameter("value_groupquery");
+                String typeStr = request.getParameter("type");
 
-				String result = decomposeValidateQuery(validationQuery_attribute_values,validationQuery_presentationtype);
-				request.setAttribute("validationQuery_result", result);		
-			}			
-			else if ("checkAccessIds".equals(event)) {
-				log.debug("checkAccessIds called");
-				request.setAttribute("tab", "6");
-				String checkAccessIds_attribute_values = request.getParameter("checkAccessIds_attribute_values");				                                                           		
-				String checkAccessIds_presentationtype = request.getParameter("checkAccessIds_presentationtype");
-				String checkAccessIds_ids = request.getParameter("checkAccessIds_ids");
-				
-				request.setAttribute("checkAccessIds_attribute_values", checkAccessIds_attribute_values);
-				request.setAttribute("checkAccessIds_presentationtype", checkAccessIds_presentationtype);
-				request.setAttribute("checkAccessIds_ids", checkAccessIds_ids);
+                boolean isKlausulering = false;
 
-				String result = decomposCheckAccessIds(checkAccessIds_attribute_values,checkAccessIds_presentationtype,checkAccessIds_ids);
-				request.setAttribute("checkAccessIds_result", result);		
-			}			
-			else if ("deletePresentationType".equals(event)) {
-				log.debug("deletePresentationType called");
-				request.setAttribute("tab", "1");
-				String typeName = request.getParameter("typeName");				                                                           				
-				LicenseModuleFacade.deletePresentationType(typeName);
-			}
-			else if ("deleteGroupType".equals(event)) {
-				log.debug("deleteGroup called");
-				request.setAttribute("tab", "2");
-				String typeName = request.getParameter("typeName");				                                                           				
-				LicenseModuleFacade.deleteLicenseGroupType(typeName);
-			}
-			else if ("deleteAttributeType".equals(event)) {
-				log.debug("deleteAttributeType called");
-				request.setAttribute("tab", "3");
-				String typeName = request.getParameter("typeName");				                                                           				
-				LicenseModuleFacade.deleteAttributeType(typeName);
-			}
-			else if ("updateGroup".equals(event)) {
-				log.debug("updateGroup called");
-				request.setAttribute("tab", "2");
+                if ("klausulering".equals(typeStr)) { 
+                    isKlausulering = true;
+                }
+                log.debug("Saving new grouptype:" + key +" klausulering:"+isKlausulering);
+                LicenseModuleFacade.persistLicenseGroupType(key,value_dk,value_en,description,description_en,query, isKlausulering);
 
-				String id = request.getParameter("id");
-				//String key = request.getParameter("key");//Not used. Update by ID.
-				String value = request.getParameter("value_grouptype");
-				String value_en = request.getParameter("value_en_grouptype");
-				String description = request.getParameter("value_groupdescription");
-				String description_en = request.getParameter("value_en_groupdescription");
-				String query = request.getParameter("value_groupquery");
-				String isRestrictionGroupStr = request.getParameter("denyGroupCheck");
-				boolean isRestrictionGroup = false;
+            } else if ("save_attributetype".equals(event)) {
 
-				if (isRestrictionGroupStr != null) { // Checkbox is checked
-					isRestrictionGroup = true;
-				}
-				log.debug("Updating license group with id:" + id);
-				LicenseModuleFacade.updateLicenseGroupType(Long.parseLong(id),value, value_en,description,description_en, query, isRestrictionGroup);
-			}						
-			else if ("updatePresentationType".equals(event)) {
-				log.debug("updatePresentationType called");
-				request.setAttribute("tab", "1");
-				String id = request.getParameter("id");
-				//String key = request.getParameter("key");//Not used. Update by ID.
-				String value = request.getParameter("value_presentationtype");
-				String value_en = request.getParameter("value_en_presentationtype");							
-				log.debug("Updating presentatintype with id:" + id);
-				LicenseModuleFacade.updatePresentationType(Long.parseLong(id),value, value_en);
-			}						
-			else {								
-				log.error("Unknown event:" + event);
-				request.setAttribute("message", "Unknown event:"+event);
-			}
+                request.setAttribute("tab", "3");
+                String value = request.getParameter("value_attributetype");
+                log.debug("Saving new attributetype:" + value);
+                LicenseModuleFacade.persistAttributeType(value);
 
-		} catch (Exception e) {//various server errors
-			log.error("unexpected error", e);
-			request.setAttribute("message", e.getMessage());
-			returnFormPage(request, response);
-			return;
-		}
-		
-		returnFormPage(request, response);
-		return;
-	}
+            } else if ("validate".equals(event)) {
+                log.debug("validate called");
+                request.setAttribute("tab", "4");
+                String validation_attribute_values = request.getParameter("validation_attribute_values");				                                                           		
+                String validation_groups = request.getParameter("validation_groups");
+                String validation_presentationtype = request.getParameter("validation_presentationtype");
 
-	private void returnFormPage(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
-		RequestDispatcher dispatcher = request.getRequestDispatcher("configuration.jsp");
-		dispatcher.forward(request, response);
-		return;
-	}
-
-	private String decomposeValidateAccess (String validation_attribute_values, String validation_groups, String validation_presentationtype) throws Exception{
-		StringBuilder infoMessage = new StringBuilder();   
-		//parse input first.
-		ValidateAccessInputDto input = new ValidateAccessInputDto();
-		PresentationType presentationType = null;
-		ArrayList<UserObjAttributeDto> attributes;
-		try{
-
-			attributes = createUserObjFromFormData(validation_attribute_values);
-			ArrayList<String> groups = createGroupsFromFormData(validation_groups);		
-			ArrayList<String> presentationTypes = createPresentationTypesFromFormData(validation_presentationtype);
-			if (presentationTypes.size() !=1){
-				infoMessage.append("Der skal angives een presentationstype");
-				return infoMessage.toString();	
-			}
-			presentationType = LicenseValidator.matchPresentationtype(presentationTypes.get(0));
-			input.setAttributes(attributes);
-			input.setGroups(groups);
-			input.setPresentationType(presentationTypes.get(0));
-
-		}
-		catch(Exception e){
-			infoMessage.append("Input validerings fejl fra web-form:"+e.getMessage());
-			return infoMessage.toString();
-		}        
+                request.setAttribute("validation_attribute_values", validation_attribute_values);
+                request.setAttribute("validation_groups", validation_groups);
+                request.setAttribute("validation_presentationtype", validation_presentationtype);
 
 
-		//The following logic is taken from LicenseValidator.validateAccess().
-		//I see no other way that to repeat it when I want to the decomposition.
+                String result = decomposeValidateAccess(validation_attribute_values,validation_groups,validation_presentationtype);
+                request.setAttribute("validation_result", result);		
+            }
+            else if ("validateQuery".equals(event)) {
+                log.debug("validateQuery called");
+                request.setAttribute("tab", "5");
+                String validationQuery_attribute_values = request.getParameter("validationQuery_attribute_values");				                                                           		
+                String validationQuery_presentationtype = request.getParameter("validationQuery_presentationtype");
 
-		ArrayList<GroupType> groupsType = null;
-		ArrayList<GroupType> restrictionGroups = null; 
-		try{
-			boolean validated = LicenseValidator.validateAccess(input);
-			infoMessage.append("Resultat af validateAccess() kald:"+validated +" \n");
-			infoMessage.append("Detaljer: \n");
-			groupsType = LicenseValidator.buildGroups(input.getGroups());
-			restrictionGroups = LicenseValidator.filterRestrictionGroups(groupsType);
-			if (restrictionGroups.size() > 0){
-				infoMessage.append("Restriction-grupper i input:"+restrictionGroups +"\n");	
-			}
-			else{
-				infoMessage.append("Der blev ikke fundet Restriction-grupper i input.\n");				
-			}
+                request.setAttribute("validationQuery_attribute_values", validationQuery_attribute_values);
+                request.setAttribute("validationQuery_presentationtype", validationQuery_presentationtype);
 
-			ArrayList<License> allLicenses = LicenseCache.getAllLicense();
-			infoMessage.append("Samlet antal licenser i databasen:"+allLicenses.size()+"\n");		
+                String result = decomposeValidateQuery(validationQuery_attribute_values,validationQuery_presentationtype);
+                request.setAttribute("validationQuery_result", result);		
+            }			
+            else if ("checkAccessIds".equals(event)) {
+                log.debug("checkAccessIds called");
+                request.setAttribute("tab", "6");
+                String checkAccessIds_attribute_values = request.getParameter("checkAccessIds_attribute_values");				                                                           		
+                String checkAccessIds_presentationtype = request.getParameter("checkAccessIds_presentationtype");
+                String checkAccessIds_ids = request.getParameter("checkAccessIds_ids");
 
-			ArrayList<License> dateFilteredLicenses = LicenseValidator.filterLicenseByValidDate(allLicenses, System.currentTimeMillis());	
-			infoMessage.append("Samlet antal licenser inden for perioden:"+dateFilteredLicenses.size()+"\n");
+                request.setAttribute("checkAccessIds_attribute_values", checkAccessIds_attribute_values);
+                request.setAttribute("checkAccessIds_presentationtype", checkAccessIds_presentationtype);
+                request.setAttribute("checkAccessIds_ids", checkAccessIds_ids);
 
-			ArrayList<License> accessLicenses = LicenseValidator.findLicensesValidatingAccess(input.getAttributes(),dateFilteredLicenses);
-			infoMessage.append("Følgende licenser opfylder access-krav(uden check af grupper):"+accessLicenses+"\n");
-			if (accessLicenses.size()==0){
-				infoMessage.append("Ingen licenser opfylder access-krav(uden check af grupper) \n");	
-				return infoMessage.toString();
-			}
+                String result = decomposCheckAccessIds(checkAccessIds_attribute_values,checkAccessIds_presentationtype,checkAccessIds_ids);
+                request.setAttribute("checkAccessIds_result", result);		
+            }			
+            else if ("deletePresentationType".equals(event)) {
+                log.debug("deletePresentationType called");
+                request.setAttribute("tab", "1");
+                String typeName = request.getParameter("typeName");				                                                           				
+                LicenseModuleFacade.deletePresentationType(typeName);
+            }
+            else if ("deleteGroupType".equals(event)) {
+                log.debug("deleteGroup called");
+                request.setAttribute("tab", "2");
+                String typeName = request.getParameter("typeName");				                                                           				
+                LicenseModuleFacade.deleteLicenseGroupType(typeName);
+            }
+            else if ("deleteAttributeType".equals(event)) {
+                log.debug("deleteAttributeType called");
+                request.setAttribute("tab", "3");
+                String typeName = request.getParameter("typeName");				                                                           				
+                LicenseModuleFacade.deleteAttributeType(typeName);
+            }
+            else if ("updateGroup".equals(event)) {
+                log.debug("updateGroup called");
+                request.setAttribute("tab", "2");
+
+                String id = request.getParameter("id");
+                //String key = request.getParameter("key");//Not used. Update by ID.
+                String value = request.getParameter("value_grouptype");
+                String value_en = request.getParameter("value_en_grouptype");
+                String description = request.getParameter("value_groupdescription");
+                String description_en = request.getParameter("value_en_groupdescription");
+                String query = request.getParameter("value_groupquery");
+                String isRestrictionGroupStr = request.getParameter("denyGroupCheck");
+                boolean isRestrictionGroup = false;
+
+                if (isRestrictionGroupStr != null) { // Checkbox is checked
+                    isRestrictionGroup = true;
+                }
+                log.debug("Updating license group with id:" + id);
+                LicenseModuleFacade.updateLicenseGroupType(Long.parseLong(id),value, value_en,description,description_en, query, isRestrictionGroup);
+            }						
+            else if ("updatePresentationType".equals(event)) {
+                log.debug("updatePresentationType called");
+                request.setAttribute("tab", "1");
+                String id = request.getParameter("id");
+                //String key = request.getParameter("key");//Not used. Update by ID.
+                String value = request.getParameter("value_presentationtype");
+                String value_en = request.getParameter("value_en_presentationtype");							
+                log.debug("Updating presentatintype with id:" + id);
+                LicenseModuleFacade.updatePresentationType(Long.parseLong(id),value, value_en);
+            }						
+            else {								
+                log.error("Unknown event:" + event);
+                request.setAttribute("message", "Unknown event:"+event);
+            }
+
+        } catch (Exception e) {//various server errors
+            log.error("unexpected error", e);
+            request.setAttribute("message", e.getMessage());
+            returnFormPage(request, response);
+            return;
+        }
+
+        returnFormPage(request, response);
+        return;
+    }
+
+    private void returnFormPage(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        RequestDispatcher dispatcher = request.getRequestDispatcher("configuration.jsp");
+        dispatcher.forward(request, response);
+        return;
+    }
+
+    private String decomposeValidateAccess (String validation_attribute_values, String validation_groups, String validation_presentationtype) throws Exception{
+        StringBuilder infoMessage = new StringBuilder();   
+        //parse input first.
+        ValidateAccessInputDto input = new ValidateAccessInputDto();
+        PresentationType presentationType = null;
+        ArrayList<UserObjAttributeDto> attributes;
+        try{
+
+            attributes = createUserObjFromFormData(validation_attribute_values);
+            ArrayList<String> groups = createGroupsFromFormData(validation_groups);		
+            ArrayList<String> presentationTypes = createPresentationTypesFromFormData(validation_presentationtype);
+            if (presentationTypes.size() !=1){
+                infoMessage.append("Der skal angives een presentationstype");
+                return infoMessage.toString();	
+            }
+            presentationType = LicenseValidator.matchPresentationtype(presentationTypes.get(0));
+            input.setAttributes(attributes);
+            input.setGroups(groups);
+            input.setPresentationType(presentationTypes.get(0));
+
+        }
+        catch(Exception e){
+            infoMessage.append("Input validerings fejl fra web-form:"+e.getMessage());
+            return infoMessage.toString();
+        }        
 
 
-			//Test method getUsersLicenseGroups
-			GetUsersLicensesInputDto inputGroups = new GetUsersLicensesInputDto();
-			inputGroups.setAttributes(attributes);						
+        //The following logic is taken from LicenseValidator.validateAccess().
+        //I see no other way that to repeat it when I want to the decomposition.
 
-			if (restrictionGroups.size() == 0){
-				log.error("presentationtype:"+presentationType);
-				ArrayList<License> validatedLicenses = LicenseValidator.filterLicensesWithGroupNamesAndPresentationTypeNoRestrictionGroup(accessLicenses, groupsType, presentationType);
+        ArrayList<GroupType> groupsType = null;
+        ArrayList<GroupType> restrictionGroups = null; 
+        try{
+            boolean validated = LicenseValidator.validateAccess(input);
+            infoMessage.append("Resultat af validateAccess() kald:"+validated +" \n");
+            infoMessage.append("Detaljer: \n");
+            groupsType = LicenseValidator.buildGroups(input.getGroups());
+            restrictionGroups = LicenseValidator.filterRestrictionGroups(groupsType);
+            if (restrictionGroups.size() > 0){
+                infoMessage.append("Restriction-grupper i input:"+restrictionGroups +"\n");	
+            }
+            else{
+                infoMessage.append("Der blev ikke fundet Restriction-grupper i input.\n");				
+            }
 
-				if (validatedLicenses.size() == 0){				
-					infoMessage.append("Ingen licenser opfylder gruppe betingelsen. \n");		
-				}
-				else{				
-					infoMessage.append("Følgende license opfylder gruppe-betingelsen:"+validatedLicenses +"\n");				
-				}								        	          
-			}
-			else{
-				ArrayList<License> validatedLicenses = LicenseValidator.filterLicensesWithGroupNamesAndPresentationTypeRestrictionGroup(accessLicenses, restrictionGroups , presentationType);
-				if (validatedLicenses.size() == 0){
-					infoMessage.append("Access-krav licenserne opfylder ikke alle Restriction-gruppe betingelser.\n");		
-				}
-				else{
-					infoMessage.append("Følgende licenser opfylder tilsammen Restriction-gruppe betingelser:"+validatedLicenses +"\n");				
-				}
-			}		
-			//infoMessage.append("Generated Query:"+userGroupsDTO.getQueryString());
-		}
+            ArrayList<License> allLicenses = LicenseCache.getAllLicense();
+            infoMessage.append("Samlet antal licenser i databasen:"+allLicenses.size()+"\n");		
 
-		catch(Exception e){
-			infoMessage.append("Fejl under validateAccess kald:"+e.getMessage());	
-			return infoMessage.toString();
-		}
-		return infoMessage.toString();
-	}
+            ArrayList<License> dateFilteredLicenses = LicenseValidator.filterLicenseByValidDate(allLicenses, System.currentTimeMillis());	
+            infoMessage.append("Samlet antal licenser inden for perioden:"+dateFilteredLicenses.size()+"\n");
+
+            ArrayList<License> accessLicenses = LicenseValidator.findLicensesValidatingAccess(input.getAttributes(),dateFilteredLicenses);
+            infoMessage.append("Følgende licenser opfylder access-krav(uden check af grupper):"+accessLicenses+"\n");
+            if (accessLicenses.size()==0){
+                infoMessage.append("Ingen licenser opfylder access-krav(uden check af grupper) \n");	
+                return infoMessage.toString();
+            }
 
 
-	private String decomposeValidateQuery (String validation_attribute_values,  String validation_presentationtypes) throws Exception{
-		StringBuilder infoMessage = new StringBuilder();   
-		//parse input first.
-		GetUserQueryInputDto input = new GetUserQueryInputDto();
-		ArrayList<UserObjAttributeDto> attributes;
-		try{
+            //Test method getUsersLicenseGroups
+            GetUsersLicensesInputDto inputGroups = new GetUsersLicensesInputDto();
+            inputGroups.setAttributes(attributes);						
 
-			attributes = createUserObjFromFormData(validation_attribute_values);		
-			ArrayList<String> presentationTypes = createPresentationTypesFromFormData(validation_presentationtypes);
-			if (presentationTypes.size() == 0){
-				infoMessage.append("Der skal angives een presentationstype");
-				return infoMessage.toString();	
-			}
-			input.setAttributes(attributes);
+            if (restrictionGroups.size() == 0){
+                log.error("presentationtype:"+presentationType);
+                ArrayList<License> validatedLicenses = LicenseValidator.filterLicensesWithGroupNamesAndPresentationTypeNoRestrictionGroup(accessLicenses, groupsType, presentationType);
 
-			input.setPresentationType(presentationTypes.get(0));
+                if (validatedLicenses.size() == 0){				
+                    infoMessage.append("Ingen licenser opfylder gruppe betingelsen. \n");		
+                }
+                else{				
+                    infoMessage.append("Følgende license opfylder gruppe-betingelsen:"+validatedLicenses +"\n");				
+                }								        	          
+            }
+            else{
+                ArrayList<License> validatedLicenses = LicenseValidator.filterLicensesWithGroupNamesAndPresentationTypeRestrictionGroup(accessLicenses, restrictionGroups , presentationType);
+                if (validatedLicenses.size() == 0){
+                    infoMessage.append("Access-krav licenserne opfylder ikke alle Restriction-gruppe betingelser.\n");		
+                }
+                else{
+                    infoMessage.append("Følgende licenser opfylder tilsammen Restriction-gruppe betingelser:"+validatedLicenses +"\n");				
+                }
+            }		
+            //infoMessage.append("Generated Query:"+userGroupsDTO.getQueryString());
+        }
 
-		}
-		catch(Exception e){
-			infoMessage.append("Input validerings fejl fra web-form:"+e.getMessage());
-			return infoMessage.toString();
-		}        
+        catch(Exception e){
+            infoMessage.append("Fejl under validateAccess kald:"+e.getMessage());	
+            return infoMessage.toString();
+        }
+        return infoMessage.toString();
+    }
 
 
-		//The following logic is taken from LicenseValidator.getUserQuery
-		//I see no other way that to repeat it when I want to the decomposition.
+    private String decomposeValidateQuery (String validation_attribute_values,  String validation_presentationtypes) throws Exception{
+        StringBuilder infoMessage = new StringBuilder();   
+        //parse input first.
+        GetUserQueryInputDto input = new GetUserQueryInputDto();
+        ArrayList<UserObjAttributeDto> attributes;
+        try{
 
-		try{
-			GetUserQueryOutputDto output = LicenseValidator.getUserQuery(input);
-			infoMessage.append("Detaljer: \n");
-			infoMessage.append("Brugeren opfylder følgende grupper:"+output.getUserLicenseGroups() +"\n");
-			infoMessage.append("Brugeren mangler følgende Restriction grupper:"+output.getUserNotInDenyGroups() +"\n");	
-			infoMessage.append("Query:"+output.getQuery() +"\n");
-		}
-		catch(Exception e){
-			infoMessage.append("Fejl under validateQuery kald:"+e.getMessage());	
-			return infoMessage.toString();
-		}
-		return infoMessage.toString();
-	}
+            attributes = createUserObjFromFormData(validation_attribute_values);		
+            ArrayList<String> presentationTypes = createPresentationTypesFromFormData(validation_presentationtypes);
+            if (presentationTypes.size() == 0){
+                infoMessage.append("Der skal angives een presentationstype");
+                return infoMessage.toString();	
+            }
+            input.setAttributes(attributes);
 
-	private String decomposCheckAccessIds(String checkAccessIds_attribute_values,  String checkAccessIds_presentationtype, String checkAccessIds_ids) throws Exception{
-		StringBuilder infoMessage = new StringBuilder();   
-		CheckAccessForIdsInputDto input = new CheckAccessForIdsInputDto();
-		ArrayList<UserObjAttributeDto> attributes;
-		try{
-			attributes = createUserObjFromFormData(checkAccessIds_attribute_values);		
-			input.setAttributes(attributes);
-			input.setPresentationType(checkAccessIds_presentationtype);
-   input.setAccessIds(createIdsFormData(checkAccessIds_ids));			
-			
-		}
-		catch(Exception e){
-			infoMessage.append("Input validerings fejl fra web-form:"+e.getMessage());
-			return infoMessage.toString();
-		}        
+            input.setPresentationType(presentationTypes.get(0));
 
-		try{
-			CheckAccessForIdsOutputDto output = LicenseValidator.checkAccessForIds(input);
-			infoMessage.append("Detaljer: \n");			
-			infoMessage.append("Presentationtype:"+output.getPresentationType() +" \n");
-			infoMessage.append("Access query part:"+output.getQuery() +" \n");
-			infoMessage.append("#Ids:"+output.getAccessIds().size() +" \n");
-			infoMessage.append("Ids:"+output.getAccessIds() +" \n");						
-		}
-		catch(Exception e){
-			infoMessage.append("Fejl under checkAccessIds kald:"+e.getMessage());	
-			return infoMessage.toString();
-		}
-		return infoMessage.toString();
-	}
+        }
+        catch(Exception e){
+            infoMessage.append("Input validerings fejl fra web-form:"+e.getMessage());
+            return infoMessage.toString();
+        }        
 
-	
 
-	private ArrayList<String> createGroupsFromFormData(String validation_groups){
-		ArrayList<String> groups = new ArrayList<String>();
-		String[] tmp = validation_groups.split(",");   //StringUtils.split(validation_groups, ",");
-		if (tmp.length == 0){
-			throw new IllegalArgumentException("Der skal være angivet mindst en gruppe i attributegrupper feltet");
-		}
-		for (String group : tmp){
-			groups.add(group.trim());
-		}		  
-		return groups;		
-	}
+        //The following logic is taken from LicenseValidator.getUserQuery
+        //I see no other way that to repeat it when I want to the decomposition.
 
-	private List<String> createIdsFormData(String validation_ids){
-		ArrayList<String> ids = new ArrayList<String>();
-		String[] tmp = validation_ids.split(","); //StringUtils.split(validation_ids, ",");
-		if (tmp.length == 0){
-			throw new IllegalArgumentException("Der skal være angivet mindst et recordId");
-		}
-		for (String id : tmp){
-			ids.add(id.trim());
-		}		  
-		return ids;		
-	}
-	
-	private ArrayList<String> createPresentationTypesFromFormData(String validation_presentationTypes){
-		ArrayList<String> presentationTypes = new ArrayList<String>();
-		String[] tmp = validation_presentationTypes.split(","); //StringUtils..split(validation_presentationTypes, ",");
-		if (tmp.length == 0){
-			throw new IllegalArgumentException("Der skal være angivet mindst en presentationtype");
-		}
-		for (String group : tmp){
-			presentationTypes.add(group.trim());
-		}		  
-		return presentationTypes;		
-	}
+        try{
+            GetUserQueryOutputDto output = LicenseValidator.getUserQuery(input);
+            infoMessage.append("Detaljer: \n");
+            infoMessage.append("Brugeren opfylder følgende grupper:"+output.getUserLicenseGroups() +"\n");
+            infoMessage.append("Brugeren mangler følgende Restriction grupper:"+output.getUserNotInDenyGroups() +"\n");	
+            infoMessage.append("Query:"+output.getQuery() +"\n");
+        }
+        catch(Exception e){
+            infoMessage.append("Fejl under validateQuery kald:"+e.getMessage());	
+            return infoMessage.toString();
+        }
+        return infoMessage.toString();
+    }
 
-	private ArrayList<UserObjAttributeDto> createUserObjFromFormData(String validation_attribute_values){
-		String[] lines = validation_attribute_values.split("\n"); //StringUtils.split(validation_attribute_values, "\n");
-		if (lines.length == 0){
-			throw new IllegalArgumentException("Der skal være mindst 1 linie i attribut/values tekstboksen");
-		}
+    private String decomposCheckAccessIds(String checkAccessIds_attribute_values,  String checkAccessIds_presentationtype, String checkAccessIds_ids) throws Exception{
+        StringBuilder infoMessage = new StringBuilder();   
+        CheckAccessForIdsInputDto input = new CheckAccessForIdsInputDto();
+        ArrayList<UserObjAttributeDto> attributes;
+        try{
+            attributes = createUserObjFromFormData(checkAccessIds_attribute_values);		
+            input.setAttributes(attributes);
+            input.setPresentationType(checkAccessIds_presentationtype);
+            input.setAccessIds(createIdsFormData(checkAccessIds_ids));			
 
-		ArrayList<UserObjAttributeDto> attributes = new ArrayList<UserObjAttributeDto>(); 
-		// every line on the form attributename: value1 , value2, value 3 ,...
-		for (String line : lines){
-			UserObjAttributeDto attribute = new UserObjAttributeDto();
-			attributes.add(attribute);
-			String[] tmp = line.split(":");//StringUtils.split(line, ":");
-			if (tmp.length != 2){
-				throw new IllegalArgumentException("Attribute/value linie kan ikke parses. Der skal være et : efter attributename for linie:"+line);
-			}
-			attribute.setAttribute(tmp[0].trim());
-			String[] values = tmp[1].split(","); //StringUtils.split(tmp[1], ",");
-			if (values.length == 0){
-				throw new IllegalArgumentException("Der skal være mindst en attributevalue for linie:"+line);
-			}
+        }
+        catch(Exception e){
+            infoMessage.append("Input validerings fejl fra web-form:"+e.getMessage());
+            return infoMessage.toString();
+        }        
 
-			ArrayList<String> valueList = new ArrayList<String>(); 
-			for (String value : values){
-				valueList.add(value.trim());
-			}
-			attribute.setValues(valueList);	   	
+        try{
+            CheckAccessForIdsOutputDto output = LicenseValidator.checkAccessForIds(input, ServiceConfig.SOLR_FILTER_ID_FIELD);
+            infoMessage.append("Detaljer: \n");			
+            infoMessage.append("Presentationtype:"+output.getPresentationType() +" \n");
+            infoMessage.append("Access query part:"+output.getQuery() +" \n");
+            infoMessage.append("#Ids:"+output.getAccessIds().size() +" \n");
+            infoMessage.append("Ids:"+output.getAccessIds() +" \n");						
+        }
+        catch(Exception e){
+            infoMessage.append("Fejl under checkAccessIds kald:"+e.getMessage());	
+            return infoMessage.toString();
+        }
+        return infoMessage.toString();
+    }
 
-		}
-		return attributes;
-	}
+
+
+    private ArrayList<String> createGroupsFromFormData(String validation_groups){
+        ArrayList<String> groups = new ArrayList<String>();
+        String[] tmp = validation_groups.split(",");   //StringUtils.split(validation_groups, ",");
+        if (tmp.length == 0){
+            throw new IllegalArgumentException("Der skal være angivet mindst en gruppe i attributegrupper feltet");
+        }
+        for (String group : tmp){
+            groups.add(group.trim());
+        }		  
+        return groups;		
+    }
+
+    private List<String> createIdsFormData(String validation_ids){
+        ArrayList<String> ids = new ArrayList<String>();
+        String[] tmp = validation_ids.split(","); //StringUtils.split(validation_ids, ",");
+        if (tmp.length == 0){
+            throw new IllegalArgumentException("Der skal være angivet mindst et recordId");
+        }
+        for (String id : tmp){
+            ids.add(id.trim());
+        }		  
+        return ids;		
+    }
+
+    private ArrayList<String> createPresentationTypesFromFormData(String validation_presentationTypes){
+        ArrayList<String> presentationTypes = new ArrayList<String>();
+        String[] tmp = validation_presentationTypes.split(","); //StringUtils..split(validation_presentationTypes, ",");
+        if (tmp.length == 0){
+            throw new IllegalArgumentException("Der skal være angivet mindst en presentationtype");
+        }
+        for (String group : tmp){
+            presentationTypes.add(group.trim());
+        }		  
+        return presentationTypes;		
+    }
+
+    private ArrayList<UserObjAttributeDto> createUserObjFromFormData(String validation_attribute_values){
+        String[] lines = validation_attribute_values.split("\n"); //StringUtils.split(validation_attribute_values, "\n");
+        if (lines.length == 0){
+            throw new IllegalArgumentException("Der skal være mindst 1 linie i attribut/values tekstboksen");
+        }
+
+        ArrayList<UserObjAttributeDto> attributes = new ArrayList<UserObjAttributeDto>(); 
+        // every line on the form attributename: value1 , value2, value 3 ,...
+        for (String line : lines){
+            UserObjAttributeDto attribute = new UserObjAttributeDto();
+            attributes.add(attribute);
+            String[] tmp = line.split(":");//StringUtils.split(line, ":");
+            if (tmp.length != 2){
+                throw new IllegalArgumentException("Attribute/value linie kan ikke parses. Der skal være et : efter attributename for linie:"+line);
+            }
+            attribute.setAttribute(tmp[0].trim());
+            String[] values = tmp[1].split(","); //StringUtils.split(tmp[1], ",");
+            if (values.length == 0){
+                throw new IllegalArgumentException("Der skal være mindst en attributevalue for linie:"+line);
+            }
+
+            ArrayList<String> valueList = new ArrayList<String>(); 
+            for (String value : values){
+                valueList.add(value.trim());
+            }
+            attribute.setValues(valueList);	   	
+
+        }
+        return attributes;
+    }
 
 }

--- a/src/main/java/dk/kb/license/solr/AbstractSolrJClient.java
+++ b/src/main/java/dk/kb/license/solr/AbstractSolrJClient.java
@@ -19,8 +19,6 @@ import dk.kb.license.config.ServiceConfig;
 
 public class AbstractSolrJClient {
     private static final Logger log = LoggerFactory.getLogger(AbstractSolrJClient.class);
-    private static String filterIdField;
-    private static String filterResourceIdField;
     
     protected HttpSolrClient solrServer; 
     static{ 
@@ -31,70 +29,49 @@ public class AbstractSolrJClient {
         System.setProperty("org.apache.commons.logging.simplelog.log.org.apache.http", "ERROR"); 
         System.setProperty("org.apache.commons.logging.simplelog.log.org.apache.http.headers", "ERROR");        
         java.util.logging.Logger.getLogger("org.apache.http.wire").setLevel(java.util.logging.Level.OFF); 
-        java.util.logging.Logger.getLogger("org.apache.http.headers").setLevel(java.util.logging.Level.OFF);
-   
-        filterIdField=ServiceConfig.SOLR_FILTER_ID_FIELD;
-        filterResourceIdField= ServiceConfig.SOLR_FILTER_RESOURCE_ID_FIELD;
+        java.util.logging.Logger.getLogger("org.apache.http.headers").setLevel(java.util.logging.Level.OFF);   
     }
 
-  
+    
+    
     /**
-     * Filter ID using the primary ID field 
-     *  
-     */      
-    public List<String> filterIds(List<String> ids, String queryPartAccess) throws Exception{
-
-        if (ids == null || ids.size() == 0){
-            return new ArrayList<String>();
-        }
-
-        String queryStr= makeAuthIdPart(ids,filterIdField); 
-        System.out.println("query:"+queryStr);
-        
-        SolrQuery query = new SolrQuery( queryStr);        
-        
-        query.setFilterQueries(queryPartAccess);
-        log.debug("filter:"+queryPartAccess);
-        
-        query.setFields(filterIdField); //only this field is used from resultset
-        query.setRows(Math.min(10000, ids.size()*200)); // Powerrating... each page can have max 200 segments (rare).. with 20 pages query this is 4000..               
-        query.set("facet", "false"); //  Must be parameter set, because this java method does NOT work: query.setFacet(false);          
-        QueryResponse response = solrServer.query(query);        
-        ArrayList<String> filteredIds = getIdsFromResponse(response,ServiceConfig.SOLR_FILTER_ID_FIELD);
-
-        return filteredIds;
-
-    }
-     
-    /**
-     * Filter resourceIDs from the resourceid field (multifield in solr)
+     * Filter ID for a given ID field. Both id and resource_id are used as id's
      * This method is used for record resources such as images 
      *  
      */
-    public List<String> filterResourceIds(List<String> ids, String queryPartAccess) throws Exception{
+    public List<String> filterIds(List<String> ids, String queryPartAccess, String solrIdField) throws Exception{
 
         if (ids == null || ids.size() == 0){
             return new ArrayList<String>();
         }
 
-        String queryStr= makeAuthIdPart(ids, ServiceConfig.SOLR_FILTER_RESOURCE_ID_FIELD); 
-        System.out.println("query:"+queryStr);
+        String queryStr= makeAuthIdPart(ids, solrIdField); 
+
         
         SolrQuery query = new SolrQuery( queryStr);        
         
-        query.setFilterQueries(queryPartAccess);
-        log.debug("filter:"+queryPartAccess);
+        if (queryPartAccess != null) { //Can be used without filter
+          query.setFilterQueries(queryPartAccess);
+          log.debug("filter:"+queryPartAccess);
+        }
         
-        query.setFields(filterResourceIdField); //only this field is used from resultset
+        query.setFields(solrIdField); //only this field is used from resultset
         query.setRows(Math.min(10000, ids.size()*200)); // Powerrating... each page can have max 200 segments (rare).. with 20 pages query this is 4000..               
         query.set("facet", "false"); //  Must be parameter set, because this java method does NOT work: query.setFacet(false);          
         QueryResponse response = solrServer.query(query); 
         log.info("response:"+response);
-        ArrayList<String> filteredIds = getIdsFromResponse(response, ServiceConfig.SOLR_FILTER_RESOURCE_ID_FIELD);
-
+        ArrayList<String> filteredIds = getIdsFromResponse(response, solrIdField);
+               
+        
         return filteredIds;
 
     }
+     
+    
+  
+  
+     
+   
      
     
     

--- a/src/main/java/dk/kb/license/validation/LicenseValidator.java
+++ b/src/main/java/dk/kb/license/validation/LicenseValidator.java
@@ -1,5 +1,6 @@
 package dk.kb.license.validation;
 
+import java.time.chrono.IsoEra;
 import java.util.*;
 
 import org.apache.commons.lang3.StringUtils;
@@ -25,628 +26,660 @@ import dk.kb.util.webservice.exception.InvalidArgumentServiceException;
 
 public class LicenseValidator {
 
-	private static final Logger log = LoggerFactory.getLogger(LicenseValidator.class);		
-	public static final String LOCALE_DA = "da";
-	public static final String LOCALE_EN = "en";
-	public static final String NO_ACCESS = ServiceConfig.SOLR_FILTER_ID_FIELD+":NoAccess";
+    private static final Logger log = LoggerFactory.getLogger(LicenseValidator.class);		
+    public static final String LOCALE_DA = "da";
+    public static final String LOCALE_EN = "en";
+    public static final String NO_ACCESS = ServiceConfig.SOLR_FILTER_ID_FIELD+":NoAccess";
 
-	
-	
+
+
     public static final List locales=
-			     Collections.unmodifiableList(Arrays.asList(new String[] {LOCALE_DA,LOCALE_EN}));
-	
-	// The following 3 methods are the API
+            Collections.unmodifiableList(Arrays.asList(new String[] {LOCALE_DA,LOCALE_EN}));
 
-	//TODO shitload of javadoc
-	public static ArrayList<License> getUsersLicenses(GetUsersLicensesInputDto input) throws Exception{
-		//validate
-		if (input.getAttributes() == null || input.getAttributes().size() == 0){
-			log.error("No attributes defined in input.");
-			throw new IllegalArgumentException("No attributes defined in input");
-		}
+    // The following 3 methods are the API
+
+    //TODO shitload of javadoc
+    public static ArrayList<License> getUsersLicenses(GetUsersLicensesInputDto input) throws Exception{
+        //validate
+        if (input.getAttributes() == null || input.getAttributes().size() == 0){
+            log.error("No attributes defined in input.");
+            throw new IllegalArgumentException("No attributes defined in input");
+        }
         validateLocale(input.getLocale());
 
-		// First filter by valid date
-		ArrayList<License> allLicenses = LicenseCache.getAllLicense();		
-		ArrayList<License> dateFilteredLicenses = filterLicenseByValidDate(allLicenses, System.currentTimeMillis());		
+        // First filter by valid date
+        ArrayList<License> allLicenses = LicenseCache.getAllLicense();		
+        ArrayList<License> dateFilteredLicenses = filterLicenseByValidDate(allLicenses, System.currentTimeMillis());		
 
-		//Find licenses that give access (not checking groups) for the dateFiltered licenses
-		ArrayList<License> accessLicenses = findLicensesValidatingAccess(input.getAttributes(),  dateFilteredLicenses);
+        //Find licenses that give access (not checking groups) for the dateFiltered licenses
+        ArrayList<License> accessLicenses = findLicensesValidatingAccess(input.getAttributes(),  dateFilteredLicenses);
 
-		return accessLicenses;
-	}
+        return accessLicenses;
+    }
 
-	//TODO shitload of javadoc
-	public static ArrayList<UserGroupDto> getUsersGroups(GetUserGroupsInputDto input) throws Exception{
-		//validate
-		if (input.getAttributes() == null || input.getAttributes().size() == 0){
-			log.error("No attributes defined in input.");
-			throw new InvalidArgumentServiceException("No attributes defined in input");
-		}
-
-		validateLocale(input.getLocale());
-		
-		// First filter by valid date
-		ArrayList<License> allLicenses = LicenseCache.getAllLicense();		
-
-		ArrayList<License> dateFilteredLicenses = filterLicenseByValidDate(allLicenses, System.currentTimeMillis());		
-		
-		//Find licenses that give access (not checking groups) for the dateFiltered licenses
-		ArrayList<License> accessLicenses = findLicensesValidatingAccess(input.getAttributes(),  dateFilteredLicenses);
-
-		ArrayList<UserGroupDto> filteredGroups = filterGroupsWithPresentationtype(accessLicenses);
-		        
-	    LicenseValidator.fixLocale(filteredGroups, input.getLocale());       
-	    
-		return filteredGroups;
-	}
-
-	//TODO shitload of javadoc
-	public static CheckAccessForIdsOutputDto checkAccessForIds(CheckAccessForIdsInputDto input) throws Exception{
-       
-	    if  (input.getAccessIds() == null || input.getAccessIds().size() == 0){
-	        throw new InvalidArgumentServiceException("No ID's in input");	        
-	    }
-	    
-		//Get the query. This also validates the input 
-		GetUserQueryInputDto inputQuery = new GetUserQueryInputDto();		
-		inputQuery.setAttributes(input.getAttributes());
-		inputQuery.setPresentationType(input.getPresentationType());
-		GetUserQueryOutputDto query = getUserQuery(inputQuery);
-		
-		
-		CheckAccessForIdsOutputDto output = new  CheckAccessForIdsOutputDto();
-		output.setPresentationType(input.getPresentationType());
-		output.setQuery(query.getQuery());
-
-		List<SolrServerClient> servers = ServiceConfig.SOLR_SERVERS;
-	
-		  // merge (union) results.   
-        Set<String> filteredIdsSet = new HashSet<String>();
-		
-		//Next step: use Future's to make multithreaded when we get more servers. 
-		//But currently these requests are less 10 ms
-		for (SolrServerClient server: servers){
-	        List<String> filteredIds =server.filterIds(input.getAccessIds(), query.getQuery());
-	        log.info("#filtered id for server ("+input.getPresentationType()+") "+ server.getServerUrl() +" : "+filteredIds.size());
-		    filteredIdsSet.addAll(filteredIds);
-		}
-		//Now we have to remove remove ID's not asked for that are here because of multivalue field. (set intersection)
-	    filteredIdsSet.retainAll(input.getAccessIds());
-						
-		output.setAccessIds(new ArrayList<String>(filteredIdsSet));
-		//Sanity check!
-		if (output.getAccessIds().size() > input.getAccessIds().size()){
-			throw new InvalidArgumentServiceException("Security problem: More Id's in output than input. Check for query injection.");
-		}
-		
-		log.debug("#query IDs="+input.getAccessIds().size() + " returned #filtered IDs="+output.getAccessIds().size() +" using resourceId field:"+ServiceConfig.SOLR_FILTER_ID_FIELD);
-		return output;		
-	}
-
-	
-	   //TODO shitload of javadoc
-    public static CheckAccessForIdsOutputDto checkAccessForResourceIds(CheckAccessForIdsInputDto input) throws Exception{
-       
-        if  (input.getAccessIds() == null || input.getAccessIds().size() == 0){
-            throw new InvalidArgumentServiceException("No ID's in input");          
+    //TODO shitload of javadoc
+    public static ArrayList<UserGroupDto> getUsersGroups(GetUserGroupsInputDto input) throws Exception{
+        //validate
+        if (input.getAttributes() == null || input.getAttributes().size() == 0){
+            log.error("No attributes defined in input.");
+            throw new InvalidArgumentServiceException("No attributes defined in input");
         }
-        
+
+        validateLocale(input.getLocale());
+
+        // First filter by valid date
+        ArrayList<License> allLicenses = LicenseCache.getAllLicense();		
+
+        ArrayList<License> dateFilteredLicenses = filterLicenseByValidDate(allLicenses, System.currentTimeMillis());		
+
+        //Find licenses that give access (not checking groups) for the dateFiltered licenses
+        ArrayList<License> accessLicenses = findLicensesValidatingAccess(input.getAttributes(),  dateFilteredLicenses);
+
+        ArrayList<UserGroupDto> filteredGroups = filterGroupsWithPresentationtype(accessLicenses);
+
+        LicenseValidator.fixLocale(filteredGroups, input.getLocale());       
+
+        return filteredGroups;
+    }
+
+    //TODO shitload of javadoc
+    public static CheckAccessForIdsOutputDto checkAccessForIds(CheckAccessForIdsInputDto input) throws Exception{
+
+        if  (input.getAccessIds() == null || input.getAccessIds().size() == 0){
+            throw new InvalidArgumentServiceException("No ID's in input");	        
+        }
+
         //Get the query. This also validates the input 
-        GetUserQueryInputDto inputQuery = new GetUserQueryInputDto();       
+        GetUserQueryInputDto inputQuery = new GetUserQueryInputDto();		
         inputQuery.setAttributes(input.getAttributes());
         inputQuery.setPresentationType(input.getPresentationType());
         GetUserQueryOutputDto query = getUserQuery(inputQuery);
-        
-        
+
+
         CheckAccessForIdsOutputDto output = new  CheckAccessForIdsOutputDto();
         output.setPresentationType(input.getPresentationType());
         output.setQuery(query.getQuery());
 
         List<SolrServerClient> servers = ServiceConfig.SOLR_SERVERS;
-    
-          // merge (union) results.   
+
+        // merge (union) results.   
         Set<String> filteredIdsSet = new HashSet<String>();
-        
+
         //Next step: use Future's to make multithreaded when we get more servers. 
         //But currently these requests are less 10 ms
         for (SolrServerClient server: servers){
-            List<String> filteredIds =server.filterResourceIds(input.getAccessIds(), query.getQuery());
+            List<String> filteredIds =server.filterIds(input.getAccessIds(), query.getQuery(), ServiceConfig.SOLR_FILTER_ID_FIELD);
             log.info("#filtered id for server ("+input.getPresentationType()+") "+ server.getServerUrl() +" : "+filteredIds.size());
             filteredIdsSet.addAll(filteredIds);
         }
         //Now we have to remove remove ID's not asked for that are here because of multivalue field. (set intersection)
         filteredIdsSet.retainAll(input.getAccessIds());
-                        
+
         output.setAccessIds(new ArrayList<String>(filteredIdsSet));
         //Sanity check!
         if (output.getAccessIds().size() > input.getAccessIds().size()){
             throw new InvalidArgumentServiceException("Security problem: More Id's in output than input. Check for query injection.");
         }
-        
-        //log.debug("#query IDs="+input.getAccessIds().size() + " returned #filtered IDs="+output.getAccessIds().size() +" using resourceId field:"+ServiceConfig.SOLR_FILTER_RESOURCE_ID_FIELD);
-        log.debug("#query IDs="+input.getAccessIds().size() + " returned #filtered IDs="+output.getAccessIds().size() +" using resourceId field:"+ServiceConfig.SOLR_FILTER_RESOURCE_ID_FIELD + " for input IDs:"+input.getAccessIds());
+
+        log.debug("#query IDs="+input.getAccessIds().size() + " returned #filtered IDs="+output.getAccessIds().size() +" using resourceId field:"+ServiceConfig.SOLR_FILTER_ID_FIELD);
+        return output;		
+    }
+
+
+    //TODO shitload of javadoc
+    public static CheckAccessForIdsOutputDto checkAccessForResourceIds(CheckAccessForIdsInputDto input) throws Exception{
+
+        if  (input.getAccessIds() == null || input.getAccessIds().size() == 0){
+            throw new InvalidArgumentServiceException("No ID's in input");          
+        }
+        log.info("checkAccessForResourceID callled for presentationtype:"+input.getPresentationType());
+
+        //Get the query. This also validates the input 
+        GetUserQueryInputDto inputQuery = new GetUserQueryInputDto();       
+        inputQuery.setAttributes(input.getAttributes());
+        inputQuery.setPresentationType(input.getPresentationType());
+        GetUserQueryOutputDto query = getUserQuery(inputQuery);
+        log.info("QUERY MUST BE CORRECT HERE:"+query);
+        CheckAccessForIdsOutputDto output = new  CheckAccessForIdsOutputDto();
+        output.setPresentationType(input.getPresentationType());
+        output.setQuery(query.getQuery());
+
+        List<SolrServerClient> servers = ServiceConfig.SOLR_SERVERS;
+
+        // merge (union) results.   
+        Set<String> filteredIdsSet = new HashSet<String>();
+
+        //Next step: use Future's to make multithreaded when we get more servers. 
+        //But currently these requests are less 10 ms
+        for (SolrServerClient server: servers){
+            log.info("filtering ID and using query:"+query.getQuery());
+            List<String> filteredIds =server.filterIds(input.getAccessIds(), query.getQuery(),ServiceConfig.SOLR_FILTER_RESOURCE_ID_FIELD);
+            log.info("#filtered id for server ("+input.getPresentationType()+") "+ server.getServerUrl() +" : "+filteredIds.size());
+            filteredIdsSet.addAll(filteredIds);
+        }
+        //Now we have to remove remove ID's not asked for that are here because of multivalue field. (set intersection)
+        filteredIdsSet.retainAll(input.getAccessIds());
+        output.setAccessIds(new ArrayList<String>(filteredIdsSet));
+        //Sanity check!
+        if (output.getAccessIds().size() > input.getAccessIds().size()){
+            throw new InvalidArgumentServiceException("Security problem: More Id's in output than input. Check for query injection.");
+        }
+
+        ArrayList<String> existingResourceIds = filterResourceIDsThatExists(input.getAccessIds());
+        //TODO remove those that already was in access list (due to multi field in solr)
+        existingResourceIds.removeAll(output.getAccessIds());
+             
+        output.setNonAccessIds(existingResourceIds);
+
+        log.debug("#query IDs="+input.getAccessIds().size() + " returned #filtered IDs="+output.getAccessIds().size() +" using resourceId field:"+ServiceConfig.SOLR_FILTER_RESOURCE_ID_FIELD + " for input IDs:"+input.getAccessIds() +" non-access IDS:"+output.getNonAccessIds());
         return output;      
     }
 
-	
-	
-	//TODO shitload of javadoc
-	public static GetUserQueryOutputDto getUserQuery(GetUserQueryInputDto input) throws Exception{
-		//validate
-		if (input.getAttributes() == null){
-			log.error("No attributes defined in input.");
-			input.setAttributes(new ArrayList<UserObjAttributeDto>());
-			
-		}		
-
-		if (input.getPresentationType() == null){
-			log.error("No presentationtype defined in input.");
-			throw new InvalidArgumentServiceException("No presentationtype defined in input.");
-		}
 
 
-		//Will throw exception if not matched		
+    //TODO shitload of javadoc
+    public static GetUserQueryOutputDto getUserQuery(GetUserQueryInputDto input) throws Exception{
+
+        //validate
+        if (input.getAttributes() == null){
+            log.error("No attributes defined in input.");
+            input.setAttributes(new ArrayList<UserObjAttributeDto>());
+
+        }		
+
+        if (input.getPresentationType() == null){
+            log.error("No presentationtype defined in input.");
+            throw new InvalidArgumentServiceException("No presentationtype defined in input.");
+        }
+
+
+        //Will throw exception if not matched		
         matchPresentationtype(input.getPresentationType());		
 
 
-		// First filter by valid date
-		ArrayList<License> allLicenses = LicenseCache.getAllLicense();		
-		ArrayList<License> dateFilteredLicenses = filterLicenseByValidDate(allLicenses, System.currentTimeMillis());		
-
-		//Find licenses that give access (not checking groups) for the dateFiltered licenses
-		ArrayList<License> accessLicenses = findLicensesValidatingAccess(input.getAttributes(),  dateFilteredLicenses);
-
-		ArrayList<String> types = new ArrayList<String>();
-		types.add(input.getPresentationType());
-		
-		ArrayList<String> filterGroups = filterGroups(accessLicenses,  types);
-
-		//Now we have to find all restriction-groups the user is missing 
-		ArrayList<GroupType> configuredRestrictionLicenseGroupTypes = LicenseCache.getConfiguredRestrictionLicenseGroupTypes();
-		GetUserQueryOutputDto output = new GetUserQueryOutputDto();
-		output.setUserLicenseGroups(filterGroups);
-
-		ArrayList<String> missingRestrictionGroups = new ArrayList<String>();
-		//First add all restriction groups then remove those that user has access too
-		for (GroupType current : configuredRestrictionLicenseGroupTypes){
-			missingRestrictionGroups.add(current.getKey());
-		}
-
-		for (String current : filterGroups){
-			missingRestrictionGroups.remove(current); 
-		}
- 		output.setUserNotInDenyGroups(missingRestrictionGroups);	
-
-		String query = generateQueryString(filterGroups, missingRestrictionGroups);
-		output.setQuery(query);
-		return output;
-	}
-
-
-	//TODO shitload of javadoc
-	public static boolean validateAccess(ValidateAccessInputDto input) throws Exception{
-
-		//validate
-		if (input.getAttributes() == null || input.getAttributes().size() == 0){
-			log.error("No attributes defined in input.");
-			throw new InvalidArgumentServiceException("No attributes defined in input");
-		}
-
-
-		PresentationType presentationType = matchPresentationtype(input.getPresentationType());
-
-		//Validate presentationType exists
-		if (presentationType == null){
-			log.warn("Unknown presentationtype in validateAccess:"+input.getPresentationType());			
-			throw new InvalidArgumentServiceException("Unknown presentationtype in validateAccess:"+input.getPresentationType());
-		}
-
-		ArrayList<GroupType> groups = buildGroups(input.getGroups());
-		//Validate groups. Same size or one was not matched.
-		if (groups.size() != input.getGroups().size()){
-			log.warn("At least 1 unknown group  in validateAccess:"+input.getGroups());			
-			throw new InvalidArgumentServiceException("At least 1 unknown group  in validateAccess:"+input.getGroups());
-		}		
-
-		ArrayList<GroupType> restrictionGroups = filterRestrictionGroups(groups);
-		if (restrictionGroups.size() > 0){
-			log.debug("At least 1 restriction groups found in input, number of Restriction-groups:"+restrictionGroups.size());			
-		}
-
-		// First filter by valid date
-		ArrayList<License> allLicenses = LicenseCache.getAllLicense();		
-		ArrayList<License> dateFilteredLicenses = filterLicenseByValidDate(allLicenses, System.currentTimeMillis());		
-
-		//Find licenses that give access (not checking groups) for the dateFiltered licenses
-		ArrayList<License> accessLicenses = findLicensesValidatingAccess(input.getAttributes(),  dateFilteredLicenses);
-
-		if (accessLicenses.size()==0){
-			log.debug("No licenses validate access-part");
-			return false;
-		}
-
-		//two situations. At least one restriction group involved, or no restriction groups.
-		if (restrictionGroups.size() == 0){
-			log.debug("Case: no restrriction group");		
-			//Simple situation. Just need to find 1 license having one of the groups with allowed presentationtype
-			ArrayList<License> validatedLicenses = filterLicensesWithGroupNamesAndPresentationTypeNoRestrictionGroup(accessLicenses, groups, presentationType);
-			return (validatedLicenses.size() >0); //OK since at least 1 license found        	           
-		}
-		else{
-			// ALL groups+presentationtype must be in at least 1 license
-			//Only Restriction groups are checked
-			log.debug("Case: at least 1 Restriction group");
-			//notice only the restrictionGroups are used
-			ArrayList<License> validatedLicenses = filterLicensesWithGroupNamesAndPresentationTypeRestrictionGroup(accessLicenses, restrictionGroups , presentationType);
-			return (validatedLicenses.size() >0); //OK since at least 1 license found
-		}
-	}
-
-	// Helper method below
-
-
-	//Collect all dom group names. Why does the caller(API) not want to know about the presentationtypes?
-	public static ArrayList<String> filterGroups(ArrayList<License> licenses) {
-		HashSet<String> groups = new HashSet<String>();
-		for (License current : licenses){
-			for (LicenseContent currentContent : current.getLicenseContents()){
-				groups.add(currentContent.getName());
-			}
-		}		
-		return new ArrayList<String>(groups);
-	}
-
-
-	//Get all dom-groups and for each dom-group find the union of presentationtypes
-	//Sort by dom group name
-	public static ArrayList<UserGroupDto> filterGroupsWithPresentationtype(ArrayList<License> licenses){
-		TreeMap<String, UserGroupDto> groups = new TreeMap<String, UserGroupDto>();
-		for (License currentLicense : licenses){
-			for (LicenseContent currentGroup : currentLicense.getLicenseContents()){
-				String name = currentGroup.getName();
-				UserGroupDto group = groups.get(name);
-				if (group == null){
-					group = new UserGroupDto();        	
-					group.setPresentationTypes(new ArrayList<String>());
-					group.setGroupName(name);
-					groups.put(name,group);
-				}
-				for (Presentation currentPresentation: currentGroup.getPresentations()){
-					String presentation_key = currentPresentation.getKey();
-					if (group.getPresentationTypes().contains(presentation_key)){
-						//Already added
-					}
-					else{
-						group.getPresentationTypes().add(presentation_key);
-					}
-				}
-			}
-		}
-		return new ArrayList<UserGroupDto>(groups.values());
-	}
-
-
-	//Collect all dom group names that have one of the given presentationtypes
-	public static ArrayList<String> filterGroups(ArrayList<License> licenses, ArrayList<String> presentationTypes) {
-		HashSet<String> groups = new  HashSet<String>();
-		for (License current : licenses){
-			for (LicenseContent currentContent : current.getLicenseContents()){
-				for (Presentation currentPresentation: currentContent.getPresentations()){
-					if (presentationTypes.contains(currentPresentation.getKey())){
-						groups.add(currentContent.getName()); 	
-
-					}				      
-				}				
-			}
-		}		
-		return new ArrayList<String>(groups);
-	}
-
-	public static ArrayList<License> filterLicenseByValidDate(ArrayList<License> licenses, long date){
-		ArrayList<License> filtered = new ArrayList<License>();
-		for (License currentLicense : licenses){
-
-			long validFromLong = Util.convertDateFormatToLong( currentLicense.getValidFrom());
-			long validToLong = Util.convertDateFormatToLong( currentLicense.getValidTo());
-
-			if (validFromLong <= date &&  date < validToLong ){ // interval: [start,end[ 
-				filtered.add(currentLicense);	
-			}
-
-		}		
-		return filtered;		
-	}
-
-
-
-	//TODO shitload oof javadoc
-	/*
-	 * This method only validates the access-part (tab #1 on the gui). For every licence every attributegroup
-	 * is validated. If an attributegroup validates, the license is added to the return list.
-	 * 
-	 */
-	public static ArrayList<License> findLicensesValidatingAccess(List<UserObjAttributeDto> attributes, ArrayList<License> allLicenses){		
-		ArrayList<License> licenses = new  ArrayList<License>();
-
-		//Iterate all licenses and test accesss
-		boolean validatedForAtLeastOneLicense = false;
-		for (License currentLicense : allLicenses){
-			boolean licenseAllreadyAdded=false;
-			//for each license check all attributegroups
-			ArrayList<AttributeGroup> groups = currentLicense.getAttributeGroups();
-			for (AttributeGroup currentGroup : groups){			 
-				boolean allAttributeGroupPartsMatched = true;
-				for (Attribute currentAttribute : currentGroup.getAttributes()){
-					ArrayList<UserObjAttributeDto> filtered = filterUserObjAttributesToValidatedOnly(currentAttribute, attributes);
-					if (filtered.size() == 0){ //Found attributegroup-part did not validate
-						allAttributeGroupPartsMatched = false; //Could break, but finding all attributegroup-parts matches is useful for debug purpose
-					}					
-				}
-
-				if (allAttributeGroupPartsMatched && ! licenseAllreadyAdded){				
-					validatedForAtLeastOneLicense=true;
-					licenseAllreadyAdded=true;
-					licenses.add(currentLicense);
-					log.debug("For license:"+ currentLicense.getLicenseName() + " VALIDATED for attributegroup number:"+currentGroup.getNumber());					
-
-				}
-				else{
-					log.debug("For license:"+ currentLicense.getLicenseName() + " FAILED VALIDATE for attributegroup number:"+currentGroup.getNumber());
-				}
-			}
-		}
-		log.info("Validate completed, access="+validatedForAtLeastOneLicense);
-		return licenses;
-	}
-
-	//Filter so only the UserObjAttribute that match the license are returned. Values that does not match are also removed.
-	public static ArrayList<UserObjAttributeDto> filterUserObjAttributesToValidatedOnly(Attribute licenseattribute,  List<UserObjAttributeDto> userAttributes){
-		String name = licenseattribute.getAttributeName();
-		ArrayList<AttributeValue> values = licenseattribute.getValues();		
-		ArrayList<UserObjAttributeDto> filteredUserObjAttributes = new ArrayList<UserObjAttributeDto>();
-
-		for (UserObjAttributeDto currentUserObjAttribute : userAttributes){
-			UserObjAttributeDto newFilteredObjAttribute = new UserObjAttributeDto(); //will be added to list returned if match		     
-			ArrayList<String> newFilteredObjAttributeValues = new ArrayList<String>(); 
-			newFilteredObjAttribute.setValues(newFilteredObjAttributeValues);
-			if (currentUserObjAttribute.getAttribute().equals(name)){ //We have an attribute match, see if any values match				 
-				newFilteredObjAttribute.setAttribute(name); //Name match, but does any values also match?
-				for (String currentObjAttributeValue : currentUserObjAttribute.getValues()){ 
-					if (containsName(values,currentObjAttributeValue)){//Value match, add to filtered						
-						newFilteredObjAttributeValues.add(currentObjAttributeValue);						  
-					}					 
-				}            	 
-			}
-			if (newFilteredObjAttributeValues.size() >0){ //we actually found attribute name and at least 1 value
-				filteredUserObjAttributes.add(newFilteredObjAttribute); 
-			}
-		}
-
-		return filteredUserObjAttributes;		
-	}
-
-
-
-	//For the restriction group situation. All groups must be matched (not necessary by same license, all groups having the given presentationtype)  	
-	public static ArrayList<License> filterLicensesWithGroupNamesAndPresentationTypeRestrictionGroup(ArrayList<License> licenses,
-			ArrayList<GroupType> groups, PresentationType presentationType){
-
-		//Iterator over groups first, since each must be found
-		HashSet<License> filteredSet = new HashSet<License>(); 
-		int groupsFound = 0;
-		for (GroupType currentGroup : groups){
-			String groupKey = currentGroup.getKey();
-
-			for (License currentLicense : licenses){
-				boolean found = Util.groupsContainsGroupWithLicense(currentLicense.getLicenseContents(), groupKey, presentationType.getKey());                 
-				if (found){ 
-					groupsFound++; //Can only happen once for each group due to the break below from inner loop
-					filteredSet.add(currentLicense); 				
-					break; // Group found, break inner loop			   
-				}
-			}			
-		}
-		if (groupsFound == groups.size()){ //All groups was matched
-			return new ArrayList<License>(filteredSet);
-		}
-
-		return new ArrayList<License>(); //Empty list.
-
-	}
-
-
-	//For the no restriction group situation. Just one of the groups has to be matched
-	//return when first license validate
-	public static ArrayList<License> filterLicensesWithGroupNamesAndPresentationTypeNoRestrictionGroup(ArrayList<License> licenses,
-			ArrayList<GroupType> groups, PresentationType presentationType){
-		ArrayList<License> filtered= new  ArrayList<License>();
-		for (License currentLicense : licenses){		
-			for (GroupType currentGroup : groups){
-				String groupKey = currentGroup.getKey();
-				if (Util.groupsContainsGroupWithLicense(currentLicense.getLicenseContents(), groupKey, presentationType.getKey())){			     			        	 
-					filtered.add(currentLicense);
-
-					return filtered;
-				} 
-			}			 
-		}
-		return filtered; //Will be empty list
-	}
-
-
-
-
-	//Will remove all non restriction-groups. 
-	public static ArrayList<GroupType> filterRestrictionGroups(ArrayList<GroupType> groups){
-		ArrayList<GroupType> filteredGroups = new ArrayList<GroupType>();
-
-		for (GroupType currentGroup : groups){
-			//TODO performence tuning, use cachedMap of GroupTypes.		
-			if ( currentGroup.isRestrictionGroup() ){
-				filteredGroups.add(currentGroup);
-			}				   
-		}			
-		return filteredGroups;
-	}
-
-	//Maps the groups(String names) to the configured objects. 
-	public static ArrayList<GroupType> buildGroups(List<String> groups){
-		ArrayList<GroupType> filteredGroups = new ArrayList<GroupType>();
-		ArrayList<GroupType> configuredGroups = LicenseCache.getConfiguredLicenseGroupTypes();
-
-		HashMap<String,GroupType> configuredGroupsNamesMap = new HashMap<String, GroupType>();
-		for (GroupType current : configuredGroups){
-			configuredGroupsNamesMap.put(current.getKey(), current);  
-		}				   
-
-		for (String currentGroup : groups){
-			if (configuredGroupsNamesMap.containsKey(currentGroup)){
-				filteredGroups.add(configuredGroupsNamesMap.get(currentGroup));
-			}
-			else{
-				log.error("Group not found in Group configuration:"+currentGroup);
-				throw new InvalidArgumentServiceException("Unknown group:"+currentGroup);
-			}
-
-
-		}		
-		return filteredGroups;
-	}
-
-	public static PresentationType matchPresentationtype(String presentationTypeName){
-
-		ArrayList<PresentationType> configuredTypes = LicenseCache.getConfiguredLicenseTypes();
-		for (PresentationType currentType : configuredTypes){
-			if (currentType.getKey().equals(presentationTypeName)){
-				return currentType;
-			}
-
-		}				
-		throw new InvalidArgumentServiceException("Unknown presentationType:"+presentationTypeName);		
-	}
-
-
-	//Return true of any of the AttributeValues in the list has value =valueToFind
-	private static boolean containsName( ArrayList<AttributeValue> values, String valueToFind){
-
-		for (AttributeValue current : values){
-			if (current.getValue().equals(valueToFind)){
-				return true;
-			}
-		}
-		return false;
-	}
-
-	public static String generateQueryString(ArrayList<String> accessGroups, ArrayList<String> missingRestrictionGroups){
-		if (accessGroups.size() == 0){
-			log.info("User does not have access to any group");
-			return NO_ACCESS;
-		}
-
-		ArrayList<GroupType> accessGroupsType = buildGroups(accessGroups);
-		ArrayList<GroupType> missingRestrictionGroupsType = buildGroups(missingRestrictionGroups);
-
-		StringBuilder query = new StringBuilder(); 
-
-
-		query.append("(("); //Outer around everything
-		for (int i = 0; i<accessGroupsType.size(); i++){			
-		    String queryPart = accessGroupsType.get(i).getQuery();
-		    if (StringUtils.isBlank(queryPart)){ //Hack to allow empty queries.
-	               continue; //Skip
-	        }
-		    		    
-		    if (i >0){
-				query.append("OR ");
-			}
-
-			query.append("(");			
-			query.append(queryPart);
-
-			query.append(")");
-			if (i <accessGroupsType.size()-1){
-				query.append(" ");
-			}
-		}  
-		query.append(")");
-
-
-		if (missingRestrictionGroupsType.size() == 0){
-			return query.toString()+")"; //closing outer
-		}
-
-		for (int i = 0; i<missingRestrictionGroupsType.size(); i++){
-		    String queryPart = missingRestrictionGroupsType.get(i).getQuery();
-		    if (StringUtils.isBlank(queryPart)){ //Hack to allow empty queries.
-		       continue; //Skip
-		    }
-		    
-		    query.append(" -(");
-			query.append(queryPart);
-			query.append(")");
-		}
+        // First filter by valid date
+        ArrayList<License> allLicenses = LicenseCache.getAllLicense();		
+        ArrayList<License> dateFilteredLicenses = filterLicenseByValidDate(allLicenses, System.currentTimeMillis());		
+
+        //Find licenses that give access (not checking groups) for the dateFiltered licenses
+        ArrayList<License> accessLicenses = findLicensesValidatingAccess(input.getAttributes(),  dateFilteredLicenses);
+
+        ArrayList<String> types = new ArrayList<String>();
+        types.add(input.getPresentationType());
+
+        ArrayList<String> filterGroups = filterGroups(accessLicenses,  types);
+        
+        //Now we have to find all restriction-groups the user is missing 
+        ArrayList<GroupType> configuredRestrictionLicenseGroupTypes = LicenseCache.getConfiguredRestrictionLicenseGroupTypes();
+        GetUserQueryOutputDto output = new GetUserQueryOutputDto();
+        output.setUserLicenseGroups(filterGroups);
+
+        ArrayList<String> missingRestrictionGroups = new ArrayList<String>();
+        //First add all restriction groups then remove those that user has access too
+        for (GroupType current : configuredRestrictionLicenseGroupTypes){
+            missingRestrictionGroups.add(current.getKey());
+        }
+
+        for (String current : filterGroups){
+            missingRestrictionGroups.remove(current); 
+        }
+        output.setUserNotInDenyGroups(missingRestrictionGroups);	
+
+        String query = generateQueryString(filterGroups, missingRestrictionGroups);
+
+        output.setQuery(query);
+        return output;
+    }
+
+
+    //TODO shitload of javadoc
+    public static boolean validateAccess(ValidateAccessInputDto input) throws Exception{
+
+        //validate
+        if (input.getAttributes() == null || input.getAttributes().size() == 0){
+            log.error("No attributes defined in input.");
+            throw new InvalidArgumentServiceException("No attributes defined in input");
+        }
+
+
+        PresentationType presentationType = matchPresentationtype(input.getPresentationType());
+
+        //Validate presentationType exists
+        if (presentationType == null){
+            log.warn("Unknown presentationtype in validateAccess:"+input.getPresentationType());			
+            throw new InvalidArgumentServiceException("Unknown presentationtype in validateAccess:"+input.getPresentationType());
+        }
+
+        ArrayList<GroupType> groups = buildGroups(input.getGroups());
+        //Validate groups. Same size or one was not matched.
+        if (groups.size() != input.getGroups().size()){
+            log.warn("At least 1 unknown group  in validateAccess:"+input.getGroups());			
+            throw new InvalidArgumentServiceException("At least 1 unknown group  in validateAccess:"+input.getGroups());
+        }		
+
+        ArrayList<GroupType> restrictionGroups = filterRestrictionGroups(groups);
+        if (restrictionGroups.size() > 0){
+            log.debug("At least 1 restriction groups found in input, number of Restriction-groups:"+restrictionGroups.size());			
+        }
+
+        // First filter by valid date
+        ArrayList<License> allLicenses = LicenseCache.getAllLicense();		
+        ArrayList<License> dateFilteredLicenses = filterLicenseByValidDate(allLicenses, System.currentTimeMillis());		
+
+        //Find licenses that give access (not checking groups) for the dateFiltered licenses
+        ArrayList<License> accessLicenses = findLicensesValidatingAccess(input.getAttributes(),  dateFilteredLicenses);
+
+        if (accessLicenses.size()==0){
+            log.debug("No licenses validate access-part");
+            return false;
+        }
+
+        //two situations. At least one restriction group involved, or no restriction groups.
+        if (restrictionGroups.size() == 0){
+            log.debug("Case: no restrriction group");		
+            //Simple situation. Just need to find 1 license having one of the groups with allowed presentationtype
+            ArrayList<License> validatedLicenses = filterLicensesWithGroupNamesAndPresentationTypeNoRestrictionGroup(accessLicenses, groups, presentationType);
+            return (validatedLicenses.size() >0); //OK since at least 1 license found        	           
+        }
+        else{
+            // ALL groups+presentationtype must be in at least 1 license
+            //Only Restriction groups are checked
+            log.debug("Case: at least 1 Restriction group");
+            //notice only the restrictionGroups are used
+            ArrayList<License> validatedLicenses = filterLicensesWithGroupNamesAndPresentationTypeRestrictionGroup(accessLicenses, restrictionGroups , presentationType);
+            return (validatedLicenses.size() >0); //OK since at least 1 license found
+        }
+    }
+
+    // Helper method below
+
+
+    //Collect all dom group names. Why does the caller(API) not want to know about the presentationtypes?
+    public static ArrayList<String> filterGroups(ArrayList<License> licenses) {
+        HashSet<String> groups = new HashSet<String>();
+        for (License current : licenses){
+            for (LicenseContent currentContent : current.getLicenseContents()){
+                groups.add(currentContent.getName());
+            }
+        }		
+        return new ArrayList<String>(groups);
+    }
+
+
+    //Get all dom-groups and for each dom-group find the union of presentationtypes
+    //Sort by dom group name
+    public static ArrayList<UserGroupDto> filterGroupsWithPresentationtype(ArrayList<License> licenses){
+        TreeMap<String, UserGroupDto> groups = new TreeMap<String, UserGroupDto>();
+        for (License currentLicense : licenses){
+            for (LicenseContent currentGroup : currentLicense.getLicenseContents()){
+                String name = currentGroup.getName();
+                UserGroupDto group = groups.get(name);
+                if (group == null){
+                    group = new UserGroupDto();        	
+                    group.setPresentationTypes(new ArrayList<String>());
+                    group.setGroupName(name);
+                    groups.put(name,group);
+                }
+                for (Presentation currentPresentation: currentGroup.getPresentations()){
+                    String presentation_key = currentPresentation.getKey();
+                    if (group.getPresentationTypes().contains(presentation_key)){
+                        //Already added
+                    }
+                    else{
+                        group.getPresentationTypes().add(presentation_key);
+                    }
+                }
+            }
+        }
+        return new ArrayList<UserGroupDto>(groups.values());
+    }
+
+
+    //Collect all  group names that have one of the given presentationtypes
+    public static ArrayList<String> filterGroups(ArrayList<License> licenses, ArrayList<String> presentationTypes) {
+        HashSet<String> groups = new  HashSet<String>();
+        for (License current : licenses){
+            for (LicenseContent currentContent : current.getLicenseContents()){
+                for (Presentation currentPresentation: currentContent.getPresentations()){
+                    if (presentationTypes.contains(currentPresentation.getKey())){
+                        groups.add(currentContent.getName()); 	
+
+                    }				      
+                }				
+            }
+        }		
+        return new ArrayList<String>(groups);
+    }
+
+    public static ArrayList<License> filterLicenseByValidDate(ArrayList<License> licenses, long date){
+        ArrayList<License> filtered = new ArrayList<License>();
+        for (License currentLicense : licenses){
+
+            long validFromLong = Util.convertDateFormatToLong( currentLicense.getValidFrom());
+            long validToLong = Util.convertDateFormatToLong( currentLicense.getValidTo());
+
+            if (validFromLong <= date &&  date < validToLong ){ // interval: [start,end[ 
+                filtered.add(currentLicense);	
+            }
+
+        }		
+        return filtered;		
+    }
+
+
+
+    //TODO shitload oof javadoc
+    /*
+     * This method only validates the access-part (tab #1 on the gui). For every licence every attributegroup
+     * is validated. If an attributegroup validates, the license is added to the return list.
+     * 
+     */
+    public static ArrayList<License> findLicensesValidatingAccess(List<UserObjAttributeDto> attributes, ArrayList<License> allLicenses){		
+        ArrayList<License> licenses = new  ArrayList<License>();
+
+        //Iterate all licenses and test accesss
+        boolean validatedForAtLeastOneLicense = false;
+        for (License currentLicense : allLicenses){
+            boolean licenseAllreadyAdded=false;
+            //for each license check all attributegroups
+            ArrayList<AttributeGroup> groups = currentLicense.getAttributeGroups();
+            for (AttributeGroup currentGroup : groups){			 
+                boolean allAttributeGroupPartsMatched = true;
+                for (Attribute currentAttribute : currentGroup.getAttributes()){
+                    ArrayList<UserObjAttributeDto> filtered = filterUserObjAttributesToValidatedOnly(currentAttribute, attributes);
+                    if (filtered.size() == 0){ //Found attributegroup-part did not validate
+                        allAttributeGroupPartsMatched = false; //Could break, but finding all attributegroup-parts matches is useful for debug purpose
+                    }					
+                }
+
+                if (allAttributeGroupPartsMatched && ! licenseAllreadyAdded){				
+                    validatedForAtLeastOneLicense=true;
+                    licenseAllreadyAdded=true;
+                    licenses.add(currentLicense);
+                    log.debug("For license:"+ currentLicense.getLicenseName() + " VALIDATED for attributegroup number:"+currentGroup.getNumber());					
+
+                }
+                else{
+                    log.debug("For license:"+ currentLicense.getLicenseName() + " FAILED VALIDATE for attributegroup number:"+currentGroup.getNumber());
+                }
+            }
+        }
+        log.info("Validate completed, access="+validatedForAtLeastOneLicense);
+        return licenses;
+    }
+
+    //Filter so only the UserObjAttribute that match the license are returned. Values that does not match are also removed.
+    public static ArrayList<UserObjAttributeDto> filterUserObjAttributesToValidatedOnly(Attribute licenseattribute,  List<UserObjAttributeDto> userAttributes){
+        String name = licenseattribute.getAttributeName();
+        ArrayList<AttributeValue> values = licenseattribute.getValues();		
+        ArrayList<UserObjAttributeDto> filteredUserObjAttributes = new ArrayList<UserObjAttributeDto>();
+
+        for (UserObjAttributeDto currentUserObjAttribute : userAttributes){
+            UserObjAttributeDto newFilteredObjAttribute = new UserObjAttributeDto(); //will be added to list returned if match		     
+            ArrayList<String> newFilteredObjAttributeValues = new ArrayList<String>(); 
+            newFilteredObjAttribute.setValues(newFilteredObjAttributeValues);
+            if (currentUserObjAttribute.getAttribute().equals(name)){ //We have an attribute match, see if any values match				 
+                newFilteredObjAttribute.setAttribute(name); //Name match, but does any values also match?
+                for (String currentObjAttributeValue : currentUserObjAttribute.getValues()){ 
+                    if (containsName(values,currentObjAttributeValue)){//Value match, add to filtered						
+                        newFilteredObjAttributeValues.add(currentObjAttributeValue);						  
+                    }					 
+                }            	 
+            }
+            if (newFilteredObjAttributeValues.size() >0){ //we actually found attribute name and at least 1 value
+                filteredUserObjAttributes.add(newFilteredObjAttribute); 
+            }
+        }
+
+        return filteredUserObjAttributes;		
+    }
+
+
+
+    //For the restriction group situation. All groups must be matched (not necessary by same license, all groups having the given presentationtype)  	
+    public static ArrayList<License> filterLicensesWithGroupNamesAndPresentationTypeRestrictionGroup(ArrayList<License> licenses,
+            ArrayList<GroupType> groups, PresentationType presentationType){
+
+        //Iterator over groups first, since each must be found
+        HashSet<License> filteredSet = new HashSet<License>(); 
+        int groupsFound = 0;
+        for (GroupType currentGroup : groups){
+            String groupKey = currentGroup.getKey();
+
+            for (License currentLicense : licenses){
+                boolean found = Util.groupsContainsGroupWithLicense(currentLicense.getLicenseContents(), groupKey, presentationType.getKey());                 
+                if (found){ 
+                    groupsFound++; //Can only happen once for each group due to the break below from inner loop
+                    filteredSet.add(currentLicense); 				
+                    break; // Group found, break inner loop			   
+                }
+            }			
+        }
+        if (groupsFound == groups.size()){ //All groups was matched
+            return new ArrayList<License>(filteredSet);
+        }
+
+        return new ArrayList<License>(); //Empty list.
+
+    }
+
+
+    //For the no restriction group situation. Just one of the groups has to be matched
+    //return when first license validate
+    public static ArrayList<License> filterLicensesWithGroupNamesAndPresentationTypeNoRestrictionGroup(ArrayList<License> licenses,
+            ArrayList<GroupType> groups, PresentationType presentationType){
+        ArrayList<License> filtered= new  ArrayList<License>();
+        for (License currentLicense : licenses){		
+            for (GroupType currentGroup : groups){
+                String groupKey = currentGroup.getKey();
+                if (Util.groupsContainsGroupWithLicense(currentLicense.getLicenseContents(), groupKey, presentationType.getKey())){			     			        	 
+                    filtered.add(currentLicense);
+
+                    return filtered;
+                } 
+            }			 
+        }
+        return filtered; //Will be empty list
+    }
+
+
+
+
+    //Will remove all non restriction-groups. 
+    public static ArrayList<GroupType> filterRestrictionGroups(ArrayList<GroupType> groups){
+        ArrayList<GroupType> filteredGroups = new ArrayList<GroupType>();
+
+        for (GroupType currentGroup : groups){
+            //TODO performence tuning, use cachedMap of GroupTypes.		
+            if ( currentGroup.isRestrictionGroup() ){
+                filteredGroups.add(currentGroup);
+            }				   
+        }			
+        return filteredGroups;
+    }
+
+    //Maps the groups(String names) to the configured objects. 
+    public static ArrayList<GroupType> buildGroups(List<String> groups){
+        ArrayList<GroupType> filteredGroups = new ArrayList<GroupType>();
+        ArrayList<GroupType> configuredGroups = LicenseCache.getConfiguredLicenseGroupTypes();
+
+        HashMap<String,GroupType> configuredGroupsNamesMap = new HashMap<String, GroupType>();
+        for (GroupType current : configuredGroups){
+            configuredGroupsNamesMap.put(current.getKey(), current);  
+        }				   
+
+        for (String currentGroup : groups){
+            if (configuredGroupsNamesMap.containsKey(currentGroup)){
+                filteredGroups.add(configuredGroupsNamesMap.get(currentGroup));
+            }
+            else{
+                log.error("Group not found in Group configuration:"+currentGroup);
+                throw new InvalidArgumentServiceException("Unknown group:"+currentGroup);
+            }
+
+
+        }		
+        return filteredGroups;
+    }
+
+    public static PresentationType matchPresentationtype(String presentationTypeName){
+
+        ArrayList<PresentationType> configuredTypes = LicenseCache.getConfiguredLicenseTypes();
+        for (PresentationType currentType : configuredTypes){
+            if (currentType.getKey().equals(presentationTypeName)){
+                return currentType;
+            }
+
+        }				
+        throw new InvalidArgumentServiceException("Unknown presentationType:"+presentationTypeName);		
+    }
+
+
+    //Return true of any of the AttributeValues in the list has value =valueToFind
+    private static boolean containsName( ArrayList<AttributeValue> values, String valueToFind){
+
+        for (AttributeValue current : values){
+            if (current.getValue().equals(valueToFind)){
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public static String generateQueryString(ArrayList<String> accessGroups, ArrayList<String> missingRestrictionGroups){
+        if (accessGroups.size() == 0){
+            log.info("User does not have access to any group");
+            return NO_ACCESS;
+        }
+
+        ArrayList<GroupType> accessGroupsType = buildGroups(accessGroups);
+        ArrayList<GroupType> missingRestrictionGroupsType = buildGroups(missingRestrictionGroups);
+
+        StringBuilder query = new StringBuilder(); 
+
+
+        query.append("(("); //Outer around everything
+        for (int i = 0; i<accessGroupsType.size(); i++){			
+            String queryPart = accessGroupsType.get(i).getQuery();
+            if (StringUtils.isBlank(queryPart)){ //Hack to allow empty queries.
+                continue; //Skip
+            }
+
+            if (i >0){
+                query.append("OR ");
+            }
+
+            query.append("(");			
+            query.append(queryPart);
+
+            query.append(")");
+            if (i <accessGroupsType.size()-1){
+                query.append(" ");
+            }
+        }  
+        query.append(")");
+
+
+        if (missingRestrictionGroupsType.size() == 0){
+            return query.toString()+")"; //closing outer
+        }
+
+        for (int i = 0; i<missingRestrictionGroupsType.size(); i++){
+            String queryPart = missingRestrictionGroupsType.get(i).getQuery();
+            if (StringUtils.isBlank(queryPart)){ //Hack to allow empty queries.
+                continue; //Skip
+            }
+
+            query.append(" -(");
+            query.append(queryPart);
+            query.append(")");
+        }
 
         query.append(")");//closing outer
 
-		return query.toString();
-	}
+        return query.toString();
+    }
 
-	public static ArrayList<String> getAllPresentationtypeNames(String locale){
-		ArrayList<String> allTypes = new ArrayList<String>(); 
-	
-		ArrayList<PresentationType> configuredTypes = LicenseCache.getConfiguredLicenseTypes();
-		
-		for (PresentationType current : configuredTypes){
-			if (LOCALE_EN.equals(locale)){
-				allTypes.add(current.getValue_en());				
-			}
-			else if (LOCALE_DA.equals(locale)){
-				allTypes.add(current.getValue_dk());
-			}			
-		}		
-		return allTypes;
-	}
-	
-	
-	public static ArrayList<String> getAllGroupeNames(String locale){
-		ArrayList<String> allGroups = new ArrayList<String>(); 
-	
-		ArrayList<GroupType> configuredGroups = LicenseCache.getConfiguredLicenseGroupTypes();
-		
-		for (GroupType current : configuredGroups){
-			if (LOCALE_EN.equals(locale)){
-				allGroups.add(current.getValue_en());				
-			}
-			else if (LOCALE_DA.equals(locale)){
-				allGroups.add(current.getValue_dk());
-			}			
-		}		
-		return allGroups;
-	}
-	public static void validateLocale(String locale){
-		if (locale == null){
-			return; // okie
-		}
-		if (!locales.contains(locale)){
-			throw new InvalidArgumentServiceException("Unknown locale:"+locale);
-		}		
-	}
-	
-	
-   //recursive fix group name and presentationtype names to the locale
-	public static void fixLocale( ArrayList<UserGroupDto> input, String locale){
-		if (locale == null){
-		    locale = LOCALE_DA;
-		}
-	    
-	    for (UserGroupDto current : input){
-			current.setGroupName(LicenseCache.getGroupName(current.getGroupName(), locale));
-			ArrayList<String> presentationTypesNames = new ArrayList<String>();
-			for (String name :  current.getPresentationTypes()){
-				presentationTypesNames.add(LicenseCache.getPresentationtypeName(name, locale));
-			}
-			current.setPresentationTypes(presentationTypesNames);			 
-		}		  
-	}
+    public static ArrayList<String> getAllPresentationtypeNames(String locale){
+        ArrayList<String> allTypes = new ArrayList<String>(); 
+
+        ArrayList<PresentationType> configuredTypes = LicenseCache.getConfiguredLicenseTypes();
+
+        for (PresentationType current : configuredTypes){
+            if (LOCALE_EN.equals(locale)){
+                allTypes.add(current.getValue_en());				
+            }
+            else if (LOCALE_DA.equals(locale)){
+                allTypes.add(current.getValue_dk());
+            }			
+        }		
+        return allTypes;
+    }
+
+
+    public static ArrayList<String> getAllGroupeNames(String locale){
+        ArrayList<String> allGroups = new ArrayList<String>(); 
+
+        ArrayList<GroupType> configuredGroups = LicenseCache.getConfiguredLicenseGroupTypes();
+
+        for (GroupType current : configuredGroups){
+            if (LOCALE_EN.equals(locale)){
+                allGroups.add(current.getValue_en());				
+            }
+            else if (LOCALE_DA.equals(locale)){
+                allGroups.add(current.getValue_dk());
+            }			
+        }		
+        return allGroups;
+    }
+    public static void validateLocale(String locale){
+        if (locale == null){
+            return; // okie
+        }
+        if (!locales.contains(locale)){
+            throw new InvalidArgumentServiceException("Unknown locale:"+locale);
+        }		
+    }
+
+
+    //recursive fix group name and presentationtype names to the locale
+    public static void fixLocale( ArrayList<UserGroupDto> input, String locale){
+        if (locale == null){
+            locale = LOCALE_DA;
+        }
+
+        for (UserGroupDto current : input){
+            current.setGroupName(LicenseCache.getGroupName(current.getGroupName(), locale));
+            ArrayList<String> presentationTypesNames = new ArrayList<String>();
+            for (String name :  current.getPresentationTypes()){
+                presentationTypesNames.add(LicenseCache.getPresentationtypeName(name, locale));
+            }
+            current.setPresentationTypes(presentationTypesNames);			 
+        }		  
+    }
+
+    //Check ID's and return only those that exists.
+    //TODO resource o
+    private static ArrayList<String> filterResourceIDsThatExists(List<String> noAccessIdList) throws Exception{
+        List<SolrServerClient> servers = ServiceConfig.SOLR_SERVERS;
+
+        //TODO solr lookup
+        Set<String> noAccessfilteredIdsSet = new HashSet<String>();
+        if (noAccessIdList.size() >0) {
+            for (SolrServerClient server: servers){
+                List<String> noAccessfilteredIds =server.filterIds(noAccessIdList, null, ServiceConfig.SOLR_FILTER_RESOURCE_ID_FIELD);
+                //log.info("#filtered id for server ("+input.getPresentationType()+") "+ server.getServerUrl() +" : "+filteredIds.size());
+                noAccessfilteredIdsSet.addAll(noAccessfilteredIds);
+            }
+
+            //Now we have to remove remove ID's not asked for that are here because of multivalue field. (set intersection)
+            noAccessfilteredIdsSet.retainAll(noAccessIdList);            
+        }
+
+        ArrayList<String> noAccessfilteredIdsList = new ArrayList<String>();
+        noAccessfilteredIdsList.addAll(noAccessfilteredIdsSet);        
+        return noAccessfilteredIdsList;
+
+    }
+
 }

--- a/src/main/openapi/ds-license-openapi_v1.yaml
+++ b/src/main/openapi/ds-license-openapi_v1.yaml
@@ -302,6 +302,10 @@ components:
            type: array
            items:
              type: string        
+        nonExistingIds:     
+           type: array
+           items:
+             type: string             
 
 
     ValidateAccessInput:

--- a/src/main/openapi/ds-license-openapi_v1.yaml
+++ b/src/main/openapi/ds-license-openapi_v1.yaml
@@ -77,7 +77,7 @@ paths:
     
       responses:
         '200':
-          description: 'Returns the IDs that has not been filtered by the query. Also return the Solr filter query that was used.'
+          description: 'Returns the IDs that has not been filtered by the query. Also return the Solr filter query that was used. IDs that exists but with no access will be return in nonAccessId field' 
           content:
             application/json:
               schema:
@@ -297,7 +297,11 @@ components:
         accessIds:     
            type: array
            items:
-             type: string       
+             type: string
+        nonAccessIds:     
+           type: array
+           items:
+             type: string        
 
 
     ValidateAccessInput:

--- a/src/test/java/dk/kb/license/integrationtest/LicenceSolrJClientTest.java
+++ b/src/test/java/dk/kb/license/integrationtest/LicenceSolrJClientTest.java
@@ -28,7 +28,7 @@ public class LicenceSolrJClientTest {
 
 		
 		String queryPartAccess="title:doms_radioTVCollection";
-		List<String> filteredIds =solrServer.filterIds(ids, queryPartAccess);		
+		List<String> filteredIds =solrServer.filterIds(ids, queryPartAccess, "id");		
 		System.out.println("Size:"+filteredIds.size());
 	    System.out.println(filteredIds);		
 	}


### PR DESCRIPTION
When filtering Id's (normal ID field or resource-ID field), also return ID's that does exist, but where access was not allowed.

Here is a call to devel11 that shows the new output. 
There are 3 resource ID's in the input. 1) does not exist, 2) does exist and access, **3) no access but does exist.**


EDIT this jira, to get the correct curl command. Even code-template does not fix it. 

curl -X POST "http://devel11:10001/ds-license/v1/checkAccessForResourceIds" -H  "accept: application/json" -H  "Content-Type: application/json" -d "{\"presentationType\":\"Search\",\"accessIds\":[\"id1\",\"/DAMJP2/DAM/Samlingsbilleder/0000/750/978/DNF_1955-00298_00092\",\"/DAMJP2/DAM/Samlingsbilleder/0000/532/736/KHP0147_26_037\"],\"attributes\":[{\"attribute\":\"everybody\",\"values\":[\"yes\"]}]}"

The response.
.....
accessIds":["/DAMJP2/DAM/Samlingsbilleder/0000/750/978/DNF_1955-00298_00092"],
"nonAccessIds":["/DAMJP2/DAM/Samlingsbilleder/0000/532/736/KHP0147_26_037"]
....
