### PR TITLE
Change ID verification to use POST and batches against Solr

### DIFF
--- a/src/main/java/dk/kb/license/solr/AbstractSolrJClient.java
+++ b/src/main/java/dk/kb/license/solr/AbstractSolrJClient.java
@@ -1,18 +1,20 @@
 package dk.kb.license.solr;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-
 import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.SolrQuery;
+import org.apache.solr.client.solrj.SolrRequest;
+import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.client.solrj.impl.HttpSolrClient;
 import org.apache.solr.client.solrj.response.QueryResponse;
 import org.apache.solr.common.SolrDocument;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import dk.kb.license.config.ServiceConfig;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 
 
 
@@ -38,35 +40,37 @@ public class AbstractSolrJClient {
      * Filter ID for a given ID field. Both id and resource_id are used as id's
      * This method is used for record resources such as images 
      * Will only return ID's that is part of the query request. Due to multi fields, Solr can return values that was not in the request
-     *  
-     *  @param ids List of id's that will be matched againg the solrIdField param
-     *  @param queryPartAccess A filter query used to filter the ID's. If null there is no filter used
-     *  @param solrIdField So far only options are id or resource_id field in Solr.
+     * <p>
+     * The Solr requests are issued using POST and in batches, ensuring that an arbitrary amount and size of IDs
+     * (within Solr's limits for ID size) can be handled.
+     * @param ids List of id's that will be matched againg the solrIdField param
+     * @param queryPartAccess A filter query used to filter the ID's. If null there is no filter used
+     * @param solrIdField So far only options are id or resource_id field in Solr.
      */
-    public List<String> filterIds(List<String> ids, String queryPartAccess, String solrIdField) throws Exception{
+    public List<String> filterIds(List<String> ids, String queryPartAccess, String solrIdField)
+            throws SolrServerException, IOException {
 
-        if (ids == null || ids.size() == 0){
-            return new ArrayList<String>();
+        if (ids == null || ids.isEmpty()){
+            return Collections.emptyList();
         }
 
-        String queryStr= makeAuthIdPart(ids, solrIdField); 
-
-        
-        SolrQuery query = new SolrQuery( queryStr);        
-        
+        SolrQuery query = new SolrQuery();
         if (queryPartAccess != null) { //Can be used without filter
           query.setFilterQueries(queryPartAccess);
         }
-        
         query.setFields(solrIdField); //only this field is used from resultset
         query.setRows(Math.min(10000, ids.size()*200)); // Powerrating... each page can have max 200 segments (rare).. with 20 pages query this is 4000..               
         query.set("facet", "false"); //  Must be parameter set, because this java method does NOT work: query.setFacet(false);          
-        QueryResponse response = solrServer.query(query); 
-        ArrayList<String> filteredIds = getIdsFromResponse(response, solrIdField);
+
+        ArrayList<String> filteredIds = new ArrayList<>(ids.size());
+        for (int i = 0 ; i < ids.size() ; i+=1000) { // Solr has a default max of 1024 unique clauses in a query
+            query.setQuery(makeAuthIdPart(ids.subList(i, Math.min(i+1000, ids.size())), solrIdField));
+            QueryResponse response = solrServer.query(query, SolrRequest.METHOD.POST);
+            filteredIds.addAll(getIdsFromResponse(response, solrIdField));
+        }
         //Due to multivalue fields, Solr can return ID's that was not in the  query request list
         filteredIds.retainAll(ids);               
         return filteredIds;
-
     }
        
     //Will also remove " from all ids to prevent Query-injection
@@ -81,7 +85,7 @@ public class AbstractSolrJClient {
             queryIdPart.append(filterField+":\""+id +"\"");
             if (i<ids.size()-1){
                 queryIdPart.append(" OR ");
-            }                       
+            }
         }
         queryIdPart.append(")");
         return queryIdPart.toString();


### PR DESCRIPTION
This should make ID lookup scale indefinitely as the `ds-license` API also receives requests using `POST`.

When this is accepted, it should be possible to raise the limit for the batched requests in `ds-present` back to 500 (or above).