### PR TITLE
Add caching to DsLicenseClient

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -205,6 +205,13 @@
             <version>4.0.2</version>
             <scope>provided</scope>
         </dependency>
+        <!-- https://mvnrepository.com/artifact/com.github.ben-manes.caffeine/caffeine -->
+        <!-- Used for DsLicenseClient -->
+        <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
+            <version>3.1.8</version>
+        </dependency>
 
 
         <!-- Apache CXF and servlet stuff -->

--- a/src/main/java/dk/kb/license/util/DsLicenseClient.java
+++ b/src/main/java/dk/kb/license/util/DsLicenseClient.java
@@ -99,7 +99,7 @@ public class DsLicenseClient extends DsLicenseApi {
     public DsLicenseApi cache(int cacheIDCount, long cacheIDms) {
         log.debug("Setting ID cache to count={}, ms={}", cacheIDCount, cacheIDms);
         idcache = Caffeine.newBuilder()
-                .maximumSize(cacheIDms)
+                .maximumSize(cacheIDCount)
                 .expireAfterWrite(cacheIDms, TimeUnit.MILLISECONDS)
                 .build();
         return this;

--- a/src/main/java/dk/kb/license/util/DsLicenseClient.java
+++ b/src/main/java/dk/kb/license/util/DsLicenseClient.java
@@ -50,7 +50,7 @@ public class DsLicenseClient extends DsLicenseApi {
     public static final String CACHE_ID_MS_KEY = "config.licensemodule.cache.id.ms";
     public static final long CACHE_ID_MS_DEFAULT = 60000;
 
-    private Cache<CheckAccessForIdsInputDto, CheckAccessForIdsOutputDto> idcache =
+    Cache<CheckAccessForIdsInputDto, CheckAccessForIdsOutputDto> idcache =
             Caffeine.newBuilder()
                     .maximumSize(CACHE_ID_COUNT_DEFAULT)
                     .expireAfterWrite(CACHE_ID_MS_DEFAULT, TimeUnit.MILLISECONDS)

--- a/src/main/java/dk/kb/license/util/DsLicenseClient.java
+++ b/src/main/java/dk/kb/license/util/DsLicenseClient.java
@@ -14,13 +14,20 @@
  */
 package dk.kb.license.util;
 
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import dk.kb.license.client.v1.DsLicenseApi;
 import dk.kb.license.invoker.v1.ApiClient;
+import dk.kb.license.invoker.v1.ApiException;
 import dk.kb.license.invoker.v1.Configuration;
+import dk.kb.license.model.v1.CheckAccessForIdsInputDto;
+import dk.kb.license.model.v1.CheckAccessForIdsOutputDto;
+import dk.kb.util.yaml.YAML;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.net.URI;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Client for the service. Intended for use by other projects that calls this service.
@@ -30,22 +37,86 @@ import java.net.URI;
  * </p>
  * The client is Thread safe and handles parallel requests independently.
  * It is recommended to persist the client and to re-use it between calls.
+ * <p>
+ * The client supports caching for {@link #checkAccessForIds} and {@link #checkAccessForResourceIds}.
+ * See the {@link DsLicenseApi(YAML)} constructor for details.
  */
 public class DsLicenseClient extends DsLicenseApi {
     private static final Logger log = LoggerFactory.getLogger(DsLicenseClient.class);
+
+    public static final String URL_KEY = "config.licensemodule.url";
+    public static final String CACHE_ID_COUNT_KEY = "config.licensemodule.cache.id.count";
+    public static final int CACHE_ID_COUNT_DEFAULT = 100;
+    public static final String CACHE_ID_MS_KEY = "config.licensemodule.cache.id.ms";
+    public static final long CACHE_ID_MS_DEFAULT = 60000;
+
+    Cache<CheckAccessForIdsInputDto, CheckAccessForIdsOutputDto> idcache =
+            Caffeine.newBuilder()
+                    .expireAfterWrite(60000, TimeUnit.MILLISECONDS)
+                    .maximumSize(100)
+                    .build();
+
+    /**
+     * Creates a client for the service based on YAML config with the following structure:
+     * <pre>
+     * config:
+     *   licensemodule:
+     *     url: 'http://localhost:9076/ds-license/v1' # Mandatory
+     *     cache:
+     *       id:
+     *         count: 100 # Default
+     *         ms: 60000  # Default
+     * </pre>
+     * @param yaml setup for the license client, as outlined above.
+     */
+    @SuppressWarnings("JavadocLinkAsPlainText")
+    public DsLicenseClient(YAML yaml) {
+        this(yaml.getString(URL_KEY),
+                yaml.getInteger(CACHE_ID_COUNT_KEY, CACHE_ID_COUNT_DEFAULT),
+                yaml.getLong(CACHE_ID_MS_KEY, CACHE_ID_MS_DEFAULT));
+    }
 
     /**
      * Creates a client for the service.
      * @param serviceURI the URI for the service, e.g. {@code https://example.com/ds-license/v1}.
      */
-    public DsLicenseClient(String serviceURI) {
+    public DsLicenseClient(String serviceURI, int cacheIDCount, long cacheIDms) {
         super(createClient(serviceURI));
-        log.info("Created OpenAPI client for '" + serviceURI + "'");
+        cache(cacheIDCount, cacheIDms);
+        log.info("Created OpenAPI client for '{}' with ID-cache(count={}, ms={})",
+                serviceURI, cacheIDCount, cacheIDms);
     }
 
     /**
-     * Deconstruct the given URI and use the components to create an ApiClient.
-     * @param serviceURIString an URI to a service.
+     * Adjust caching if {@link #checkAccessForIds} and {@link #checkAccessForResourceIds}.
+     * <p>
+     * Calling this method resets the cache.
+     * @param cacheIDCount the maximum number of {@link CheckAccessForIdsInputDto} to cache.
+     * @param cacheIDms the maximum amount of milliseconds for any object in the cache.
+     * @return this object with caching adjusted
+     */
+    @SuppressWarnings("UnusedReturnValue")
+    public DsLicenseApi cache(int cacheIDCount, long cacheIDms) {
+        log.debug("Setting ID cache to count={}, ms={}", cacheIDCount, cacheIDms);
+        idcache = Caffeine.newBuilder()
+                .maximumSize(cacheIDms)
+                .expireAfterWrite(cacheIDms, TimeUnit.MILLISECONDS)
+                .build();
+        return this;
+    }
+
+    /**
+     * Creates a client for the service.
+     * @param serviceURI the URI for the service, e.g. {@code https://example.com/ds-license/v1}.
+     * @deprecated use {@link DsLicenseApi(YAML)} or {@link DsLicenseApi(YAML, int, long)} instead.
+     */
+    @Deprecated
+    public DsLicenseClient(String serviceURI) {
+        this(serviceURI, CACHE_ID_COUNT_DEFAULT, CACHE_ID_MS_DEFAULT);
+    }
+
+    /**
+     * @param serviceURIString a URI to a service.
      * @return an ApiClient constructed from the serviceURIString.
      */
     private static ApiClient createClient(String serviceURIString) {
@@ -59,4 +130,78 @@ public class DsLicenseClient extends DsLicenseApi {
                 setPort(serviceURI.getPort()).
                 setBasePath(serviceURI.getRawPath());
     }
+
+    @Override
+    public CheckAccessForIdsOutputDto checkAccessForIds(CheckAccessForIdsInputDto idInputDto) throws ApiException {
+        return checkAccessForIdsGeneral(idInputDto, true);
+    }
+
+    @Override
+    public CheckAccessForIdsOutputDto checkAccessForResourceIds(CheckAccessForIdsInputDto idInputDto)
+            throws ApiException {
+        return checkAccessForIdsGeneral(idInputDto, false);
+    }
+
+    /**
+     * Bypass the cache and always perform a remote check for access.  
+     * @param idInputDto request for access information.
+     * @return direct result from {@link DsLicenseApi#checkAccessForIds} 
+     * @throws ApiException if the remote call failed.
+     */
+    public CheckAccessForIdsOutputDto directCheckAccessForIds(CheckAccessForIdsInputDto idInputDto) throws ApiException {
+        return super.checkAccessForIds(idInputDto);
+    }
+
+    /**
+     * Bypass the cache and always perform a remote check for access.  
+     * @param idInputDto request for access information.
+     * @return direct result from {@link DsLicenseApi#checkAccessForResourceIds} 
+     * @throws ApiException if the remote call failed.
+     */
+    public CheckAccessForIdsOutputDto directCheckAccessForResourceIds(CheckAccessForIdsInputDto idInputDto)
+            throws ApiException {
+        return super.checkAccessForResourceIds(idInputDto);
+    }
+
+    /**
+     * Helper for {@link #checkAccessForIds} and {@link #checkAccessForResourceIds} that takes care of wrapping and
+     * unwrapping the use of {@link #idcache}.
+     * @param idInputDto an input for either ID or resourceID lookup.
+     * @param directID if true, the given IDs are treated as primary IDs. If false, they are treated as resourceIDs.
+     *                 This switches between forwarding to {@link #checkAccessForIds} and
+     *                 {@link #checkAccessForResourceIds}.
+     * @return the response from the forward call, potentially fetched from cache.
+     * @throws ApiException if the ID access check failed.
+     */
+    public CheckAccessForIdsOutputDto checkAccessForIdsGeneral(CheckAccessForIdsInputDto idInputDto, boolean directID)
+            throws ApiException {
+        // This is a mess of try-catches, but it is hard to avoid as we really want to use the Function based
+        // idcache.get(idInputDto, inputDTO -> ...)
+        // That method guards against multiple concurrent checks for the same IDs,
+        // which is an extremely common occurrence when handling Tile based image viewing.
+        try {
+            return idcache.get(idInputDto, inputDTO -> {
+                try {
+                    return directID ?
+                            directCheckAccessForIds(inputDTO) :
+                            directCheckAccessForResourceIds(inputDTO);
+                } catch (ApiException e) { // ApiException is checked; we cannot throw those directly in lambdas
+                    throw new RuntimeException(e);
+                }
+            });
+        } catch (RuntimeException e) {
+            // If possible, locate the inner ApiException and throw that. Quite a hack, but what to do?
+            if (e.getCause() != null && e.getCause() instanceof ApiException) {
+                throw (ApiException) e.getCause();
+            } else {
+                throw e;
+            }
+        } catch (Exception e) {
+            ApiException wrapped = new ApiException(
+                    "Unknown Exception calling checkAccessForIds with directID=" + directID);
+            wrapped.initCause(e);
+            throw wrapped;
+        }
+    }
+
 }

--- a/src/main/java/dk/kb/license/util/DsLicenseClient.java
+++ b/src/main/java/dk/kb/license/util/DsLicenseClient.java
@@ -50,10 +50,10 @@ public class DsLicenseClient extends DsLicenseApi {
     public static final String CACHE_ID_MS_KEY = "config.licensemodule.cache.id.ms";
     public static final long CACHE_ID_MS_DEFAULT = 60000;
 
-    Cache<CheckAccessForIdsInputDto, CheckAccessForIdsOutputDto> idcache =
+    private Cache<CheckAccessForIdsInputDto, CheckAccessForIdsOutputDto> idcache =
             Caffeine.newBuilder()
-                    .expireAfterWrite(60000, TimeUnit.MILLISECONDS)
-                    .maximumSize(100)
+                    .maximumSize(CACHE_ID_COUNT_DEFAULT)
+                    .expireAfterWrite(CACHE_ID_MS_DEFAULT, TimeUnit.MILLISECONDS)
                     .build();
 
     /**

--- a/src/test/java/dk/kb/license/DsLicenseClientTest.java
+++ b/src/test/java/dk/kb/license/DsLicenseClientTest.java
@@ -14,10 +14,20 @@
  */
 package dk.kb.license;
 
+import dk.kb.license.invoker.v1.ApiException;
+import dk.kb.license.model.v1.CheckAccessForIdsInputDto;
+import dk.kb.license.model.v1.CheckAccessForIdsOutputDto;
 import dk.kb.license.util.DsLicenseClient;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.eq;
 
 /**
  * Simple verification of client code generation.
@@ -30,6 +40,48 @@ public class DsLicenseClientTest {
     public void testInstantiation() {
         String backendURIString = "htp://example.com/ds-license/v1";
         log.debug("Creating inactive client for ds-license with URI '{}'", backendURIString);
-        new DsLicenseClient(backendURIString);
+        new DsLicenseClient(backendURIString, 10, 5000);
+    }
+
+    @Test
+    public void testCaching() throws ApiException {
+        CheckAccessForIdsInputDto request1 = new CheckAccessForIdsInputDto().accessIds(List.of("1", "one"));
+        CheckAccessForIdsInputDto request2 = new CheckAccessForIdsInputDto().accessIds(List.of("2", "two"));
+        CheckAccessForIdsInputDto resRequest1 = new CheckAccessForIdsInputDto().accessIds(List.of("r1", "rthree"));
+
+        CheckAccessForIdsOutputDto response1 = new CheckAccessForIdsOutputDto().query("1");
+        CheckAccessForIdsOutputDto response2 = new CheckAccessForIdsOutputDto().query("2");
+        CheckAccessForIdsOutputDto resResponse1 = new CheckAccessForIdsOutputDto().query("3");
+        CheckAccessForIdsOutputDto fail = new CheckAccessForIdsOutputDto().query("Should not be returned");
+
+        // Mock the DsLicenseClient
+        DsLicenseClient clientSpy = Mockito.spy(
+                new DsLicenseClient("http://localhost:9076/ds-license/v1", 10, 60000));
+
+        doReturn(response1, fail).when(clientSpy).directCheckAccessForIds(eq(request1));
+        doReturn(response2, fail).when(clientSpy).directCheckAccessForIds(eq(request2));
+        doReturn(resResponse1, fail).when(clientSpy).directCheckAccessForResourceIds(eq(resRequest1));
+
+        assertEquals(response1, clientSpy.checkAccessForIds(request1),
+                "First call with request 1 should return response1");
+        assertEquals(response1, clientSpy.checkAccessForIds(request1),
+                "Second call with request 1 should return the initial response1");
+
+        assertEquals(response2, clientSpy.checkAccessForIds(request2),
+                "First call with request 2 should return response2");
+        assertEquals(response2, clientSpy.checkAccessForIds(request2),
+                "Second call with request 2 should return the initial response2");
+
+        assertEquals(resResponse1, clientSpy.checkAccessForResourceIds(resRequest1),
+                "First call with resource request 1 should return resource response 1");
+        assertEquals(resResponse1, clientSpy.checkAccessForResourceIds(resRequest1),
+                "Second call with resource request 1 should return initial resource response 1");
+
+        // Clear the cache, forcing a mock call to the direct-method, returning the secondary mock value 'fail'
+        assertEquals(response1, clientSpy.checkAccessForIds(request1),
+                "Third call with request 1 should return the initial response1");
+        clientSpy.cache(10, 60000);
+        assertEquals(fail, clientSpy.checkAccessForIds(request1),
+                "Fourth call with request 1 should miss the cache");
     }
 }

--- a/src/test/java/dk/kb/license/util/DsLicenseClientTest.java
+++ b/src/test/java/dk/kb/license/util/DsLicenseClientTest.java
@@ -12,12 +12,12 @@
  *  limitations under the License.
  *
  */
-package dk.kb.license;
+package dk.kb.license.util;
 
 import dk.kb.license.invoker.v1.ApiException;
 import dk.kb.license.model.v1.CheckAccessForIdsInputDto;
 import dk.kb.license.model.v1.CheckAccessForIdsOutputDto;
-import dk.kb.license.util.DsLicenseClient;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.slf4j.Logger;
@@ -35,6 +35,16 @@ import static org.mockito.Mockito.eq;
 public class DsLicenseClientTest {
     private static final Logger log = LoggerFactory.getLogger(DsLicenseClientTest.class);
 
+    // Reusable test requests & responses
+    private CheckAccessForIdsInputDto request1 = new CheckAccessForIdsInputDto().accessIds(List.of("1", "one"));
+    private CheckAccessForIdsInputDto request2 = new CheckAccessForIdsInputDto().accessIds(List.of("2", "two"));
+    private CheckAccessForIdsInputDto resRequest1 = new CheckAccessForIdsInputDto().accessIds(List.of("r1", "rthree"));
+
+    private CheckAccessForIdsOutputDto response1 = new CheckAccessForIdsOutputDto().query("1");
+    private CheckAccessForIdsOutputDto response2 = new CheckAccessForIdsOutputDto().query("2");
+    private CheckAccessForIdsOutputDto resResponse1 = new CheckAccessForIdsOutputDto().query("3");
+    private CheckAccessForIdsOutputDto fail = new CheckAccessForIdsOutputDto().query("Should not be returned");
+
     // We cannot test usage as that would require a running instance of ds-license to connect to
     @Test
     public void testInstantiation() {
@@ -45,23 +55,14 @@ public class DsLicenseClientTest {
 
     @Test
     public void testCaching() throws ApiException {
-        CheckAccessForIdsInputDto request1 = new CheckAccessForIdsInputDto().accessIds(List.of("1", "one"));
-        CheckAccessForIdsInputDto request2 = new CheckAccessForIdsInputDto().accessIds(List.of("2", "two"));
-        CheckAccessForIdsInputDto resRequest1 = new CheckAccessForIdsInputDto().accessIds(List.of("r1", "rthree"));
-
-        CheckAccessForIdsOutputDto response1 = new CheckAccessForIdsOutputDto().query("1");
-        CheckAccessForIdsOutputDto response2 = new CheckAccessForIdsOutputDto().query("2");
-        CheckAccessForIdsOutputDto resResponse1 = new CheckAccessForIdsOutputDto().query("3");
-        CheckAccessForIdsOutputDto fail = new CheckAccessForIdsOutputDto().query("Should not be returned");
-
         // Mock the DsLicenseClient
         DsLicenseClient clientSpy = Mockito.spy(
                 new DsLicenseClient("http://localhost:9076/ds-license/v1", 10, 60000));
-
         doReturn(response1, fail).when(clientSpy).directCheckAccessForIds(eq(request1));
         doReturn(response2, fail).when(clientSpy).directCheckAccessForIds(eq(request2));
         doReturn(resResponse1, fail).when(clientSpy).directCheckAccessForResourceIds(eq(resRequest1));
 
+        // Test basic caching
         assertEquals(response1, clientSpy.checkAccessForIds(request1),
                 "First call with request 1 should return response1");
         assertEquals(response1, clientSpy.checkAccessForIds(request1),
@@ -76,12 +77,53 @@ public class DsLicenseClientTest {
                 "First call with resource request 1 should return resource response 1");
         assertEquals(resResponse1, clientSpy.checkAccessForResourceIds(resRequest1),
                 "Second call with resource request 1 should return initial resource response 1");
+    }
 
-        // Clear the cache, forcing a mock call to the direct-method, returning the secondary mock value 'fail'
+    @Test
+    public void testCachingSize() throws ApiException {
+        // Mock the DsLicenseClient
+        DsLicenseClient clientSpy = Mockito.spy(
+                new DsLicenseClient("http://localhost:9076/ds-license/v1", 1, 60000));
+        doReturn(response1, fail).when(clientSpy).directCheckAccessForIds(eq(request1));
+        doReturn(response2, fail).when(clientSpy).directCheckAccessForIds(eq(request2));
+
+        // Fill the cache beyond capacity
         assertEquals(response1, clientSpy.checkAccessForIds(request1),
-                "Third call with request 1 should return the initial response1");
-        clientSpy.cache(10, 60000);
+                "First call with request 1 should return response1");
+        assertEquals(response2, clientSpy.checkAccessForIds(request2),
+                "First call with request 2 should return response2");
+
+        // Actively force the cache to check constraints (max size + age). This should flush the oldest (request1)
+        clientSpy.idcache.cleanUp();
         assertEquals(fail, clientSpy.checkAccessForIds(request1),
                 "Fourth call with request 1 should miss the cache");
     }
+
+    @Tag("slow")
+    @Test
+    public void testCachingTimeout() throws ApiException, InterruptedException {
+        // Mock the DsLicenseClient
+        DsLicenseClient clientSpy = Mockito.spy(
+                new DsLicenseClient("http://localhost:9076/ds-license/v1", 2, 1000));
+        doReturn(response1, fail).when(clientSpy).directCheckAccessForIds(eq(request1));
+
+        // Test basic caching
+        assertEquals(response1, clientSpy.checkAccessForIds(request1),
+                "First call with request 1 should return response1");
+        assertEquals(response1, clientSpy.checkAccessForIds(request1),
+                "Second call with request 1 should return the initial response1");
+
+        // Actively force the cache to check constraints (max size + age). This should change nothing at this point
+        clientSpy.idcache.cleanUp();
+
+        assertEquals(response1, clientSpy.checkAccessForIds(request1),
+                "Third call with request 1 should return the initial response1");
+
+        // Sleep longer than the cache timeout period, then force a constraint check
+        Thread.sleep(1001);
+        clientSpy.idcache.cleanUp();
+        assertEquals(fail, clientSpy.checkAccessForIds(request1),
+                "Fourth call with request 1 should miss the cache");
+    }
+
 }


### PR DESCRIPTION
To handle the use case of checking for access to bitmap tiles (many concurrent checks for the same ID with the same credentials), caching has been added to the `DsLicenseClient`. It is enabled per default with max size 100 and max age 60 seconds, but as a precaution the old constructor has been deprecated, nudging users to switch to the cache-explicit new constructors.

This also adds support for constructing the `DsLicenseClient` directly from the project config, if the config conforms to the stated structure.