### PR TITLE
Dra 1711 remove autogenerated client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added abstract class BaseModuleStorage, which handles connection to the backing storage in preparation for implementation of rights calculation.
 
+- Removed auto generated DsLicenseClient class that was a blocker for better exception handling. All DsLicenseClient methods now only throws ServiceException mapped to HTTP status code.
 - Bumped kb-util to v1.6.8 for service2service oauth support.
 - Added injection of Oauth token on all service methods when using DsLicenseClient.
 - Added DTO which contains all needed values for calculating rights.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added abstract class BaseModuleStorage, which handles connection to the backing storage in preparation for implementation of rights calculation.
 
 - Removed auto generated DsLicenseClient class that was a blocker for better exception handling. All DsLicenseClient methods now only throws ServiceException mapped to HTTP status in same way calling the API directly.
-- Bumped kb-util to v1.6.8 for service2service oauth support.
+- Bumped kb-util to v1.6.9 for service2service oauth support.
 - Added injection of Oauth token on all service methods when using DsLicenseClient.
 - Added DTO which contains all needed values for calculating rights.
 - Added ddl scripts and storage methods for restricted IDs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added abstract class BaseModuleStorage, which handles connection to the backing storage in preparation for implementation of rights calculation.
 
-- Removed auto generated DsLicenseClient class that was a blocker for better exception handling. All DsLicenseClient methods now only throws ServiceException mapped to HTTP status code.
+- Removed auto generated DsLicenseClient class that was a blocker for better exception handling. All DsLicenseClient methods now only throws ServiceException mapped to HTTP status in same way calling the API directly.
 - Bumped kb-util to v1.6.8 for service2service oauth support.
 - Added injection of Oauth token on all service methods when using DsLicenseClient.
 - Added DTO which contains all needed values for calculating rights.

--- a/pom.xml
+++ b/pom.xml
@@ -439,6 +439,12 @@
 
         <!-- https://mvnrepository.com/artifact/com.fasterxml.jackson.jaxrs/jackson-jaxrs-json-provider -->
 
+       <dependency>
+          <groupId>org.apache.httpcomponents.client5</groupId>
+          <artifactId>httpclient5</artifactId>
+          <version>5.4.2</version>
+       </dependency>
+
 
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -611,44 +611,7 @@
                         </configuration>
                     </execution>
                     <!-- Client for the backend -->
-                    <execution>
-                        <id>Generate client for JAR package and use by other services</id>
-                        <goals>
-                            <goal>generate</goal>
-                        </goals>
-                        <configuration>
-                            <inputSpec>${project.build.outputDirectory}/ds-license-openapi_v1.yaml</inputSpec>
-                            <ignoreFileOverride>${project.basedir}/.openapi-codegen-ignore-api</ignoreFileOverride>
-                            <generatorName>java</generatorName>
-                            <library>native</library>
-
-                            <!-- Do not generate doc or tests for this client, we will handle this ourselves-->
-                            <generateApis>true</generateApis>
-                            <generateApiTests>false</generateApiTests>
-                            <generateApiDocumentation>false</generateApiDocumentation>
-                            <generateModels>false</generateModels>
-                            <generateModelTests>false</generateModelTests>
-                            <generateModelDocumentation>false</generateModelDocumentation>
-
-                            <!-- Ensure ONLY the ApiClient and supporting classes are created, not the gradle mess-->
-                            <generateSupportingFiles>true</generateSupportingFiles>
-                            <supportingFilesToGenerate>ApiClient.java,ApiException.java,Configuration.java,Pair.java</supportingFilesToGenerate>
-
-                            <!-- Do NOT use the customised templates as they are only for the webservice part, not the client-->
-                            <!-- Hacked by Asger by setting to an existing folder without templates -->
-                            <templateDirectory>src/main/</templateDirectory>
-
-                            <configOptions>
-                                <apiPackage>${project.package}.client.v1</apiPackage>
-                                <modelPackage>${project.package}.model.v1</modelPackage>
-                                <invokerPackage>${project.package}.invoker.v1</invokerPackage>
-                                <sourceFolder>target/generated-sources</sourceFolder>
-                                <implFolder>target/generated-sources</implFolder>
-                            </configOptions>
-                        </configuration>
-                    </execution>
-
-                </executions>
+                 </executions>
             </plugin>
 
             <!-- The generated classes for the OpenAPI client are problematic. Disable checking of those for now -->

--- a/pom.xml
+++ b/pom.xml
@@ -191,7 +191,7 @@
         <dependency>
             <groupId>dk.kb.util</groupId>
             <artifactId>kb-util</artifactId>
-            <version>1.6.8</version>
+            <version>1.6.9</version>
         </dependency>
         <dependency>
             <groupId>jakarta.servlet</groupId>

--- a/src/main/java/dk/kb/license/util/DsLicenseClient.java
+++ b/src/main/java/dk/kb/license/util/DsLicenseClient.java
@@ -140,7 +140,7 @@ public class DsLicenseClient{
     public CheckAccessForIdsOutputDto checkAccessForResourceIds(CheckAccessForIdsInputDto idInputDto) throws ServiceException{
         try {
             URI uri = new URIBuilder(serviceURI)
-                    .appendPath("/checkAccessForResourceIds")                                                                
+                    .appendPath("checkAccessForResourceIds")                                                                
                     .build();
             return Service2ServiceRequest.httpCallWithOAuthToken(uri,"POST",new CheckAccessForIdsOutputDto(),idInputDto);              
         }
@@ -160,7 +160,7 @@ public class DsLicenseClient{
     public ValidateAccessOutputDto validateAccess(ValidateAccessInputDto idInputDto) throws ServiceException{
         try {
             URI uri = new URIBuilder(serviceURI)                                                                
-                     .appendPath("/validateAccess")
+                     .appendPath("validateAccess")
                      .build();
             return Service2ServiceRequest.httpCallWithOAuthToken(uri,"POST",new ValidateAccessOutputDto(),idInputDto);              
         }
@@ -184,7 +184,7 @@ public class DsLicenseClient{
             URI uri;
             try {
                 uri = new URIBuilder(serviceURI)
-                        .appendPath("/checkAccessForIds")                                                                
+                        .appendPath("checkAccessForIds")                                                                
                         .build();
             }
             catch (URISyntaxException e) {                
@@ -205,7 +205,7 @@ public class DsLicenseClient{
 
         try {
             URI uri = new URIBuilder(serviceURI)
-                    .appendPath("/getUserGroups")                                                                
+                    .appendPath("getUserGroups")                                                                
                     .build();
             return Service2ServiceRequest.httpCallWithOAuthToken(uri,"POST",new GetUserGroupsOutputDto(),getUserGroupsInputDto);              
         }
@@ -225,7 +225,7 @@ public class DsLicenseClient{
     public GetUserGroupsAndLicensesOutputDto getUserGroupsAndLicenses (GetUserGroupsAndLicensesInputDto getUserGroupsAndLicensesInputDto) throws ServiceException {
         try {
             URI uri = new URIBuilder(serviceURI)
-                    .appendPath("/getUserGroupsAndLicenses")                                                                                   
+                    .appendPath("getUserGroupsAndLicenses")                                                                                   
                     .build();                       
             return Service2ServiceRequest.httpCallWithOAuthToken(uri,"POST",new GetUserGroupsAndLicensesOutputDto(),getUserGroupsAndLicensesInputDto);              
         }
@@ -246,7 +246,7 @@ public class DsLicenseClient{
     public GetUsersFilterQueryOutputDto getUserLicenseQuery (GetUserQueryInputDto getUserQueryInputDto) throws ServiceException {
         try {
             URI uri = new URIBuilder(serviceURI)
-                      .appendPath("/getUserLicenseQuery")                                                                                   
+                      .appendPath("getUserLicenseQuery")                                                                                   
                     .build();                       
             return Service2ServiceRequest.httpCallWithOAuthToken(uri,"POST",new GetUsersFilterQueryOutputDto(),getUserQueryInputDto);              
         }
@@ -267,7 +267,7 @@ public class DsLicenseClient{
     public GetUsersLicensesOutputDto getUserLicenses(GetUsersLicensesInputDto getUsersLicensesInputDto) throws ServiceException {
         try {
             URI uri = new URIBuilder(serviceURI)
-                    .appendPath("/getUserLicenses")                                                                
+                    .appendPath("getUserLicenses")                                                                
                     .build();                       
             return Service2ServiceRequest.httpCallWithOAuthToken(uri,"POST",new GetUsersLicensesOutputDto(),getUsersLicensesInputDto);              
         }

--- a/src/main/java/dk/kb/license/util/DsLicenseClient.java
+++ b/src/main/java/dk/kb/license/util/DsLicenseClient.java
@@ -33,7 +33,7 @@ import dk.kb.util.webservice.exception.InternalServiceException;
 import dk.kb.util.webservice.exception.ServiceException;
 import dk.kb.util.yaml.YAML;
 
-import org.apache.http.client.utils.URIBuilder;
+import org.apache.hc.core5.net.URIBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -139,7 +139,8 @@ public class DsLicenseClient{
      */
     public CheckAccessForIdsOutputDto checkAccessForResourceIds(CheckAccessForIdsInputDto idInputDto) throws ServiceException{
         try {
-            URI uri = new URIBuilder(serviceURI + "/checkAccessForResourceIds")                                                                
+            URI uri = new URIBuilder(serviceURI)
+                    .appendPath("/checkAccessForResourceIds")                                                                
                     .build();
             return Service2ServiceRequest.httpCallWithOAuthToken(uri,"POST",new CheckAccessForIdsOutputDto(),idInputDto);              
         }
@@ -158,8 +159,9 @@ public class DsLicenseClient{
      */
     public ValidateAccessOutputDto validateAccess(ValidateAccessInputDto idInputDto) throws ServiceException{
         try {
-            URI uri = new URIBuilder(serviceURI + "/validateAccess")                                                                
-                    .build();
+            URI uri = new URIBuilder(serviceURI)                                                                
+                     .appendPath("/validateAccess")
+                     .build();
             return Service2ServiceRequest.httpCallWithOAuthToken(uri,"POST",new ValidateAccessOutputDto(),idInputDto);              
         }
         catch (URISyntaxException e) {                
@@ -181,7 +183,8 @@ public class DsLicenseClient{
     public CheckAccessForIdsOutputDto checkAccessForIds(CheckAccessForIdsInputDto idInputDto) throws ServiceException {       
             URI uri;
             try {
-                uri = new URIBuilder(serviceURI + "/checkAccessForIds")                                                                
+                uri = new URIBuilder(serviceURI)
+                        .appendPath("/checkAccessForIds")                                                                
                         .build();
             }
             catch (URISyntaxException e) {                
@@ -201,7 +204,8 @@ public class DsLicenseClient{
     public GetUserGroupsOutputDto getUserGroups (GetUserGroupsInputDto getUserGroupsInputDto) throws ServiceException {
 
         try {
-            URI uri = new URIBuilder(serviceURI + "/getUserGroups")                                                                
+            URI uri = new URIBuilder(serviceURI)
+                    .appendPath("/getUserGroups")                                                                
                     .build();
             return Service2ServiceRequest.httpCallWithOAuthToken(uri,"POST",new GetUserGroupsOutputDto(),getUserGroupsInputDto);              
         }
@@ -220,7 +224,8 @@ public class DsLicenseClient{
      */
     public GetUserGroupsAndLicensesOutputDto getUserGroupsAndLicenses (GetUserGroupsAndLicensesInputDto getUserGroupsAndLicensesInputDto) throws ServiceException {
         try {
-            URI uri = new URIBuilder(serviceURI + "/getUserGroupsAndLicenses")                                                                
+            URI uri = new URIBuilder(serviceURI)
+                    .appendPath("/getUserGroupsAndLicenses")                                                                                   
                     .build();                       
             return Service2ServiceRequest.httpCallWithOAuthToken(uri,"POST",new GetUserGroupsAndLicensesOutputDto(),getUserGroupsAndLicensesInputDto);              
         }
@@ -240,7 +245,8 @@ public class DsLicenseClient{
      */
     public GetUsersFilterQueryOutputDto getUserLicenseQuery (GetUserQueryInputDto getUserQueryInputDto) throws ServiceException {
         try {
-            URI uri = new URIBuilder(serviceURI + "/getUserLicenseQuery")                                                                
+            URI uri = new URIBuilder(serviceURI)
+                      .appendPath("/getUserLicenseQuery")                                                                                   
                     .build();                       
             return Service2ServiceRequest.httpCallWithOAuthToken(uri,"POST",new GetUsersFilterQueryOutputDto(),getUserQueryInputDto);              
         }
@@ -260,7 +266,8 @@ public class DsLicenseClient{
      */
     public GetUsersLicensesOutputDto getUserLicenses(GetUsersLicensesInputDto getUsersLicensesInputDto) throws ServiceException {
         try {
-            URI uri = new URIBuilder(serviceURI + "/getUserLicenses")                                                                
+            URI uri = new URIBuilder(serviceURI)
+                    .appendPath("/getUserLicenses")                                                                
                     .build();                       
             return Service2ServiceRequest.httpCallWithOAuthToken(uri,"POST",new GetUsersLicensesOutputDto(),getUsersLicensesInputDto);              
         }

--- a/src/main/java/dk/kb/license/util/DsLicenseClient.java
+++ b/src/main/java/dk/kb/license/util/DsLicenseClient.java
@@ -218,7 +218,7 @@ public class DsLicenseClient{
      * @return GetUserGroupsAndLicensesOutputDto
      * @throws ServiceException if fails to make API call
      */
-    public GetUserGroupsAndLicensesOutputDto getUserGroupsAndLicenses (GetUserGroupsAndLicensesInputDto getUserGroupsAndLicensesInputDto) throws Exception {
+    public GetUserGroupsAndLicensesOutputDto getUserGroupsAndLicenses (GetUserGroupsAndLicensesInputDto getUserGroupsAndLicensesInputDto) throws ServiceException {
         try {
             URI uri = new URIBuilder(serviceURI + "/getUserGroupsAndLicenses")                                                                
                     .build();                       
@@ -238,7 +238,7 @@ public class DsLicenseClient{
      * @return GetUsersFilterQueryOutputDto
      * @throws ServiceException if fails to make API call
      */
-    public GetUsersFilterQueryOutputDto getUserLicenseQuery (GetUserQueryInputDto getUserQueryInputDto) throws Exception {
+    public GetUsersFilterQueryOutputDto getUserLicenseQuery (GetUserQueryInputDto getUserQueryInputDto) throws ServiceException {
         try {
             URI uri = new URIBuilder(serviceURI + "/getUserLicenseQuery")                                                                
                     .build();                       
@@ -258,7 +258,7 @@ public class DsLicenseClient{
      * @return GetUsersLicensesOutputDto
      * @throws Exception if fails to make API call
      */
-    public GetUsersLicensesOutputDto getUserLicenses(GetUsersLicensesInputDto getUsersLicensesInputDto) throws Exception {
+    public GetUsersLicensesOutputDto getUserLicenses(GetUsersLicensesInputDto getUsersLicensesInputDto) throws ServiceException {
         try {
             URI uri = new URIBuilder(serviceURI + "/getUserLicenses")                                                                
                     .build();                       

--- a/src/main/openapi/ds-license-openapi_v1.yaml
+++ b/src/main/openapi/ds-license-openapi_v1.yaml
@@ -147,6 +147,9 @@ paths:
       tags:
         - '${project.name}'
       summary: 'Get the groups that the user has access to'
+      security: 
+        - KBOAuth:
+          - any            
       operationId: getUserGroups       
       requestBody:
         content:

--- a/src/test/java/dk/kb/license/util/DsLicenseClientCacheTest.java
+++ b/src/test/java/dk/kb/license/util/DsLicenseClientCacheTest.java
@@ -14,7 +14,6 @@
  */
 package dk.kb.license.util;
 
-import dk.kb.license.invoker.v1.ApiException;
 import dk.kb.license.model.v1.CheckAccessForIdsInputDto;
 import dk.kb.license.model.v1.CheckAccessForIdsOutputDto;
 import org.junit.jupiter.api.Tag;
@@ -54,7 +53,7 @@ public class DsLicenseClientCacheTest {
     }
 /*
     @Test
-    public void testCaching() throws ApiException {
+    public void testCaching() throws Exception {
         // Mock the DsLicenseClient
         DsLicenseClient clientSpy = Mockito.spy(
                 new DsLicenseClient("http://localhost:9076/ds-license/v1", 10, 60000));
@@ -80,7 +79,7 @@ public class DsLicenseClientCacheTest {
     }
 
     @Test
-    public void testCachingSize() throws ApiException {
+    public void testCachingSize() throws Exception {
         // Mock the DsLicenseClient
         DsLicenseClient clientSpy = Mockito.spy(
                 new DsLicenseClient("http://localhost:9076/ds-license/v1", 1, 60000));
@@ -101,7 +100,7 @@ public class DsLicenseClientCacheTest {
 
     @Tag("slow")
     @Test
-    public void testCachingTimeout() throws ApiException, InterruptedException {
+    public void testCachingTimeout() throws Exception, InterruptedException {
         // Mock the DsLicenseClient
         DsLicenseClient clientSpy = Mockito.spy(
                 new DsLicenseClient("http://localhost:9076/ds-license/v1", 2, 1000));

--- a/src/test/java/dk/kb/license/util/DsLicenseClientTest.java
+++ b/src/test/java/dk/kb/license/util/DsLicenseClientTest.java
@@ -17,7 +17,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import dk.kb.license.config.ServiceConfig;
-import dk.kb.license.invoker.v1.ApiException;
 import dk.kb.license.model.v1.CheckAccessForIdsInputDto;
 import dk.kb.license.model.v1.CheckAccessForIdsOutputDto;
 import dk.kb.license.model.v1.GetUserGroupsAndLicensesInputDto;
@@ -66,7 +65,7 @@ public class DsLicenseClientTest {
     }
 
     @Test
-    public void testCheckAccessForIds() throws ApiException {      
+    public void testCheckAccessForIds() throws Exception {      
         ArrayList<String> ids= new ArrayList<String>();
         ids.add("does_not_exist");
         CheckAccessForIdsInputDto input = getCheckAccessForIdsInputDto(SEARCH_PRESENTATIONTYPE, ids);                         
@@ -75,7 +74,7 @@ public class DsLicenseClientTest {
     }
 
     @Test
-    public void testCheckAccessForResourceIds() throws ApiException {              
+    public void testCheckAccessForResourceIds() throws Exception {              
         ArrayList<String> ids= new ArrayList<String>();
         ids.add("does_not_exist");
         CheckAccessForIdsInputDto input = getCheckAccessForIdsInputDto(SEARCH_PRESENTATIONTYPE, ids);                          
@@ -84,15 +83,17 @@ public class DsLicenseClientTest {
 
     }
 
+    
     @Test
-    public void testValidateAccess() throws ApiException {       
+    public void testValidateAccess() throws Exception {       
         ValidateAccessInputDto input = getValidateAccessInputDto(new ArrayList<String>());      
         ValidateAccessOutputDto output = remote.validateAccess(input);
         assertNotNull(output); //We have a valid response;
     }
 
+
     @Test
-    public void testUserGroups() throws ApiException {      
+    public void testUserGroups() throws Exception {      
         GetUserGroupsInputDto input = new GetUserGroupsInputDto();
         input.setLocale("da");                                                       
         input.setAttributes(getDefaultAttributes());          
@@ -101,7 +102,7 @@ public class DsLicenseClientTest {
     }
     
     @Test
-    public void testUserGroupsAndLicenses() throws ApiException {      
+    public void testUserGroupsAndLicenses() throws Exception {      
         GetUserGroupsAndLicensesInputDto input = new GetUserGroupsAndLicensesInputDto();
         input.setLocale("da");                                                       
         input.setAttributes(getDefaultAttributes());
@@ -110,7 +111,7 @@ public class DsLicenseClientTest {
     }
     
     @Test
-    public void testGetUserLicenseQuery() throws ApiException {      
+    public void testGetUserLicenseQuery() throws Exception {      
         GetUserQueryInputDto input = new GetUserQueryInputDto();                                                             
         input.setAttributes(getDefaultAttributes());
         input.setPresentationType(SEARCH_PRESENTATIONTYPE);                
@@ -120,7 +121,7 @@ public class DsLicenseClientTest {
 
     
     @Test
-    public void testGetUserLicenses() throws ApiException {      
+    public void testGetUserLicenses() throws Exception {      
         GetUsersLicensesInputDto input=new GetUsersLicensesInputDto();                                                             
         input.setAttributes(getDefaultAttributes());
         input.setLocale("da");                


### PR DESCRIPTION
DO NOT MERGE! ...before all modules are rewritten.

Removed auto generated DsLicenseClient class that was a blocker for better exception handling. All DsLicenseClient methods now only throws ServiceException mapped to HTTP status in same way calling the API directly.