### PR TITLE
Perform deletions by internal ID instead of multiple values

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -191,7 +191,7 @@
         <dependency>
             <groupId>dk.kb.util</groupId>
             <artifactId>kb-util</artifactId>
-            <version>1.6.9</version>
+            <version>1.6.10-SNAPSHOT</version>
         </dependency>
         <!-- Client for ds-storage This will also require the org.openapitools dependency-->
         <dependency>

--- a/src/main/java/dk/kb/license/api/v1/impl/DsRightsApiServiceImpl.java
+++ b/src/main/java/dk/kb/license/api/v1/impl/DsRightsApiServiceImpl.java
@@ -56,10 +56,10 @@ public class DsRightsApiServiceImpl extends ImplBase implements DsRightsApi {
     }
 
     @Override
-    public void deleteRestrictedId(String id, String idType, String platform, Boolean touchRecord) {
+    public void deleteRestrictedId(String internalId, String id, String idType, String platform, Boolean touchRecord) {
         log.debug("Deleted restricted id:{} idType:{} platform:{}", id, idType, platform);
         try {
-            RightsModuleFacade.deleteRestrictedId(id, idType, platform, getCurrentUserID(),touchRecord);
+            RightsModuleFacade.deleteRestrictedId(internalId, id, idType, platform, getCurrentUserID(),touchRecord);
         } catch (Exception e) {
             throw handleException(e);
         }

--- a/src/main/java/dk/kb/license/storage/RightsModuleStorage.java
+++ b/src/main/java/dk/kb/license/storage/RightsModuleStorage.java
@@ -49,6 +49,8 @@ public class RightsModuleStorage extends BaseModuleStorage{
             RESTRICTED_ID_IDVALUE +" = ? AND " +
             RESTRICTED_ID_IDTYPE +" = ?" ;
     private final String deleteRestrictedIdQuery = "DELETE FROM " + RESTRICTED_ID_TABLE + " WHERE " + RESTRICTED_ID_IDVALUE + " = ? AND " + RESTRICTED_ID_IDTYPE + " = ? AND " + RESTRICTED_ID_PLATFORM + " = ? ";
+    private final String deleteRestrictedIdByInternalIdQuery = "DELETE FROM " + RESTRICTED_ID_TABLE + " WHERE " + RESTRICTED_ID_ID + " = ?";
+
     private final String allRestrictedIdsQuery = "SELECT * FROM " + RESTRICTED_ID_TABLE + " WHERE " + RESTRICTED_ID_IDTYPE + " LIKE ? AND " + RESTRICTED_ID_PLATFORM + " LIKE ?";
 
     private final String DR_HOLDBACK_RULES_TABLE = "DR_HOLDBACK_RULES";
@@ -150,6 +152,7 @@ public class RightsModuleStorage extends BaseModuleStorage{
             ResultSet res = stmt.executeQuery();
             while (res.next()) {
                 RestrictedIdOutputDto output = new RestrictedIdOutputDto();
+                output.setInternalId(res.getString(RESTRICTED_ID_ID));
                 output.setIdValue(res.getString(RESTRICTED_ID_IDVALUE));
                 output.setIdType(res.getString(RESTRICTED_ID_IDTYPE));
                 output.setPlatform(res.getString(RESTRICTED_ID_PLATFORM));
@@ -194,7 +197,7 @@ public class RightsModuleStorage extends BaseModuleStorage{
     }
 
     /**
-     * Delete an entry from the restricted IDs table. Also updates the mTime of the related record in ds-storage.
+     * Delete an entry from the restricted IDs table.
      *
      * @param id_value value of the ID
      * @param id_type type of ID
@@ -209,6 +212,22 @@ public class RightsModuleStorage extends BaseModuleStorage{
             stmt.execute();
         } catch (SQLException e) {
             log.error("SQL Exception in delete restricted Id:" + e.getMessage());
+            throw e;
+        }
+    }
+
+    /**
+     * Delete an entry from the restricted IDs table by internal ID.
+     *
+     * @param internalId to delete entry for.
+     */
+    public void deleteRestrictedIdByInternalId(String internalId) throws SQLException {
+        try (PreparedStatement statement = connection.prepareStatement(deleteRestrictedIdByInternalIdQuery)) {
+            statement.setString(1, internalId);
+            int result = statement.executeUpdate();
+            log.info("Deleted '{}' documents by internal ID: '{}'", result, internalId);
+        } catch (SQLException e){
+            log.error("SQL Exception in delete internal ID: " + e.getMessage());
             throw e;
         }
     }
@@ -229,6 +248,7 @@ public class RightsModuleStorage extends BaseModuleStorage{
             List<RestrictedIdOutputDto> output = new ArrayList<>();
             while (res.next()) {
                 RestrictedIdOutputDto restrictedIdOutputDto = new RestrictedIdOutputDto();
+                restrictedIdOutputDto.setInternalId(res.getString(RESTRICTED_ID_ID));
                 restrictedIdOutputDto.setIdValue(res.getString(RESTRICTED_ID_IDVALUE));
                 restrictedIdOutputDto.setIdType(res.getString(RESTRICTED_ID_IDTYPE));
                 restrictedIdOutputDto.setPlatform(res.getString(RESTRICTED_ID_PLATFORM));

--- a/src/main/openapi/ds-license-openapi_v1.yaml
+++ b/src/main/openapi/ds-license-openapi_v1.yaml
@@ -290,10 +290,12 @@ paths:
               items:
                 $ref: '#/components/schemas/RestrictedIdInput'
             example:
-              - idValue: "test:multi:1"
+              - internalId: "internalId1"
+                idValue: "test:multi:1"
                 idType: "ds_id"
                 platform: "dr"
-              - idValue: "test:multi:3"
+              - internalId: "internalId2"
+                idValue: "test:multi:3"
                 idType: "dr_produktions_id"
                 platform: "dr"
       responses:
@@ -346,6 +348,11 @@ paths:
         - KBOAuth:
             - any
       parameters:
+        - name: internalId
+          in: query
+          required: true
+          schema:
+            type: string
         - name: id
           in: query
           required: true
@@ -993,6 +1000,8 @@ components:
         - idType
         - platform
       properties:
+        internalId:
+          type: string
         idValue:
           type: string
         idType:
@@ -1005,6 +1014,8 @@ components:
     RestrictedIdOutput:
       type: object
       properties:
+        internalId:
+          type: string
         idValue:
           type: string
         idType:


### PR DESCRIPTION
Perform the deletion in the DB by internal ID. However id_value and id_type are still needed for touching the records in the backing DsStorage