### PR TITLE
DRA-1995 created_at and created_by

### DIFF
--- a/src/main/java/dk/kb/license/storage/RightsModuleStorage.java
+++ b/src/main/java/dk/kb/license/storage/RightsModuleStorage.java
@@ -163,7 +163,7 @@ public class RightsModuleStorage extends BaseModuleStorage{
     }
 
     /**
-     * Updates an entry in the restricted IDs table. Also updates the mTime of the related record in ds-storage.
+     * Updates an entry in the restricted IDs table. Also updates the modifiedTime of the related record in ds-storage.
      *
      * @param id_value The value of the ID
      * @param id_type The type of the ID

--- a/src/main/java/dk/kb/license/storage/RightsModuleStorage.java
+++ b/src/main/java/dk/kb/license/storage/RightsModuleStorage.java
@@ -30,12 +30,14 @@ public class RightsModuleStorage extends BaseModuleStorage{
     private final String RESTRICTED_ID_IDTYPE = "id_type";
     private final String RESTRICTED_ID_PLATFORM = "platform";
     private final String RESTRICTED_ID_COMMENT = "comment";
+    private final String RESTRICTED_ID_CREATED_BY = "created_by";
+    private final String RESTRICTED_ID_CREATED_TIME = "created_time";
     private final String RESTRICTED_ID_MODIFIED_BY = "modified_by";
     private final String RESTRICTED_ID_MODIFIED_TIME = "modified_time";
 
     private final String createRestrictedIdQuery = "INSERT INTO " + RESTRICTED_ID_TABLE +
             " ("+RESTRICTED_ID_ID+","+ RESTRICTED_ID_IDVALUE +","+ RESTRICTED_ID_IDTYPE +","+ RESTRICTED_ID_PLATFORM +","+
-            RESTRICTED_ID_COMMENT +","+ RESTRICTED_ID_MODIFIED_BY +","+ RESTRICTED_ID_MODIFIED_TIME +")" +
+            RESTRICTED_ID_COMMENT +","+ RESTRICTED_ID_CREATED_BY +","+ RESTRICTED_ID_CREATED_TIME +")" +
             " VALUES (?,?,?,?,?,?,?)";
     private final String readRestrictedIdQuery = "SELECT * FROM " + RESTRICTED_ID_TABLE + " WHERE " + RESTRICTED_ID_IDVALUE + " = ? AND " + RESTRICTED_ID_IDTYPE + " = ? AND " + RESTRICTED_ID_PLATFORM + " = ? ";
     private final String readRestrictedIdQueryByInternalId = "SELECT * FROM " + RESTRICTED_ID_TABLE + " WHERE " + RESTRICTED_ID_ID + " = ?";
@@ -112,11 +114,11 @@ public class RightsModuleStorage extends BaseModuleStorage{
      * @param id_type The type of the ID
      * @param platform The platform where the object is restricted (e.g DR)
      * @param comment Just a comment
-     * @param modifiedBy The id of the user creating the restricted ID
-     * @param modifiedTime timestamp for creation
+     * @param createdBy The id of the user creating the restricted ID
+     * @param createdTime timestamp for creation
      * @throws SQLException
      */
-    public void createRestrictedId(String id_value, String id_type, String platform, String comment, String modifiedBy, long modifiedTime) throws SQLException {
+    public void createRestrictedId(String id_value, String id_type, String platform, String comment, String createdBy, long createdTime) throws SQLException {
         long uniqueID = generateUniqueID();
 
         try (PreparedStatement stmt = connection.prepareStatement(createRestrictedIdQuery)){
@@ -125,8 +127,8 @@ public class RightsModuleStorage extends BaseModuleStorage{
             stmt.setString(3, id_type);
             stmt.setString(4, platform);
             stmt.setString(5, comment);
-            stmt.setString(6, modifiedBy);
-            stmt.setLong(7, modifiedTime);
+            stmt.setString(6, createdBy);
+            stmt.setLong(7, createdTime);
             stmt.execute();
         }  catch (SQLException e) {
             log.error("SQL Exception in persistClause:" + e.getMessage());
@@ -563,6 +565,8 @@ public class RightsModuleStorage extends BaseModuleStorage{
         output.setIdType(IdTypeEnumDto.fromValue(resultSet.getString(RESTRICTED_ID_IDTYPE)));
         output.setPlatform(PlatformEnumDto.fromValue(resultSet.getString(RESTRICTED_ID_PLATFORM)));
         output.setComment(resultSet.getString(RESTRICTED_ID_COMMENT));
+        output.setCreatedBy(resultSet.getString(RESTRICTED_ID_CREATED_BY));
+        output.setCreatedTime(resultSet.getLong(RESTRICTED_ID_CREATED_TIME));
         output.setModifiedBy(resultSet.getString(RESTRICTED_ID_MODIFIED_BY));
         output.setModifiedTime(resultSet.getLong(RESTRICTED_ID_MODIFIED_TIME));
         output.setModifiedTimeHuman(convertToHumanReadable(output.getModifiedTime()));

--- a/src/main/java/dk/kb/license/storage/RightsModuleStorage.java
+++ b/src/main/java/dk/kb/license/storage/RightsModuleStorage.java
@@ -108,7 +108,7 @@ public class RightsModuleStorage extends BaseModuleStorage{
     }
 
     /**
-     * Creates an entry in the restrictedID table. Also updates the mTime for the related record in ds-storage.
+     * Creates an entry in the restrictedID table.
      *
      * @param id_value The value of the ID
      * @param id_type The type of the ID

--- a/src/main/openapi/ds-license-openapi_v1.yaml
+++ b/src/main/openapi/ds-license-openapi_v1.yaml
@@ -1049,6 +1049,10 @@ components:
           $ref: "#/components/schemas/PlatformEnum"
         comment:
           type: string
+        createdBy:
+          type: string
+        createdTime:
+          type: long
         modifiedBy:
           type: string
         modifiedTime:

--- a/src/test/java/dk/kb/license/storage/RightsModuleStorageTest.java
+++ b/src/test/java/dk/kb/license/storage/RightsModuleStorageTest.java
@@ -46,32 +46,36 @@ public class RightsModuleStorageTest extends DsLicenseUnitTestUtil   {
         String idType = IdTypeEnumDto.DR_PRODUCTION_ID.getValue();
         String platform = PlatformEnumDto.DRARKIV.getValue();
         String comment = "a comment";
-        String modified_by = "user1";
-        long modified_time = 1739439979000L;
+        String createdBy = "user1";
+        long createdTime = 1739439979000L;
 
-        storage.createRestrictedId(idValue,idType,platform,comment,modified_by,modified_time);
+        storage.createRestrictedId(idValue,idType,platform,comment,createdBy,createdTime);
         RestrictedIdOutputDto retreivedFromStorage = storage.getRestrictedId(idValue, idType, platform);
         assertNotNull(retreivedFromStorage);
         assertEquals(idValue,retreivedFromStorage.getIdValue());
         assertEquals(idType,retreivedFromStorage.getIdType().getValue());
         assertEquals(platform,retreivedFromStorage.getPlatform().getValue());
         assertEquals(comment,retreivedFromStorage.getComment());
-        assertEquals(modified_by,retreivedFromStorage.getModifiedBy());
-        assertEquals(modified_time,retreivedFromStorage.getModifiedTime());
+        assertEquals(createdBy,retreivedFromStorage.getCreatedBy());
+        assertEquals(createdTime,retreivedFromStorage.getCreatedTime());
+        assertNull(retreivedFromStorage.getModifiedBy());
+        assertEquals(0, retreivedFromStorage.getModifiedTime());
 
         String new_comment = "another comment";
-        String new_modified_by = "user2";
-        long new_modified_time = 17394500000000L;
+        String modifiedBy = "user2";
+        long modifiedTime = 17394500000000L;
 
-        storage.updateRestrictedId(idValue,idType,platform,new_comment,new_modified_by,new_modified_time);
-        retreivedFromStorage = storage.getRestrictedId(idValue, idType, platform);
-        assertNotNull(retreivedFromStorage);
-        assertEquals(idValue,retreivedFromStorage.getIdValue());
-        assertEquals(idType,retreivedFromStorage.getIdType().getValue());
-        assertEquals(platform,retreivedFromStorage.getPlatform().getValue());
-        assertEquals(new_comment,retreivedFromStorage.getComment());
-        assertEquals(new_modified_by,retreivedFromStorage.getModifiedBy());
-        assertEquals(new_modified_time,retreivedFromStorage.getModifiedTime());
+        storage.updateRestrictedId(idValue,idType,platform,new_comment,modifiedBy,modifiedTime);
+        RestrictedIdOutputDto modifiedRetreivedFromStorage = storage.getRestrictedId(idValue, idType, platform);
+        assertNotNull(modifiedRetreivedFromStorage);
+        assertEquals(idValue,modifiedRetreivedFromStorage.getIdValue());
+        assertEquals(idType,modifiedRetreivedFromStorage.getIdType().getValue());
+        assertEquals(platform,modifiedRetreivedFromStorage.getPlatform().getValue());
+        assertEquals(new_comment,modifiedRetreivedFromStorage.getComment());
+        assertEquals(createdBy,modifiedRetreivedFromStorage.getCreatedBy());
+        assertEquals(createdTime,modifiedRetreivedFromStorage.getCreatedTime());
+        assertEquals(modifiedBy,modifiedRetreivedFromStorage.getModifiedBy());
+        assertEquals(modifiedTime,modifiedRetreivedFromStorage.getModifiedTime());
 
         storage.deleteRestrictedId(idValue,idType,platform);
         assertNull(storage.getRestrictedId(idValue, idType,platform));

--- a/src/test/resources/ddl/rightsmodule_create_db.ddl
+++ b/src/test/resources/ddl/rightsmodule_create_db.ddl
@@ -1,12 +1,14 @@
 CREATE TABLE  RESTRICTED_IDS (
-                                              id BIGINT PRIMARY KEY,
-                                              id_value VARCHAR(256) NOT NULL,
-                                              id_type VARCHAR(32) NOT NULL,
-                                              platform VARCHAR(32),
-                                              comment VARCHAR(16384),
-                                              modified_by VARCHAR(256),
-                                              modified_time BIGINT,
-                                              modified_time_human VARCHAR(256)
+    id BIGINT PRIMARY KEY,
+    id_value VARCHAR(256) NOT NULL,
+    id_type VARCHAR(32) NOT NULL,
+    platform VARCHAR(32),
+    comment VARCHAR(16384),
+    created_by VARCHAR(256),
+    created_time BIGINT,
+    modified_by VARCHAR(256),
+    modified_time BIGINT,
+    modified_time_human VARCHAR(256)
 );
 
 CREATE UNIQUE INDEX unique_restricted_id ON RESTRICTED_IDS (id_value,id_type,platform);

--- a/src/test/resources/ddl/rightsmodule_create_h2_unittest.ddl
+++ b/src/test/resources/ddl/rightsmodule_create_h2_unittest.ddl
@@ -14,26 +14,26 @@ CREATE TABLE IF NOT EXISTS RESTRICTED_IDS (
 CREATE UNIQUE INDEX IF NOT EXISTS unique_restricted_id ON RESTRICTED_IDS (id_value,id_type,platform);
 
 CREATE TABLE IF NOT EXISTS DR_HOLDBACK_RULES (
-                                                 id VARCHAR(256) PRIMARY KEY,
-                                                 name VARCHAR(256),
-                                                 days int
+    id VARCHAR(256) PRIMARY KEY,
+    name VARCHAR(256),
+    days int
 );
 
 CREATE TABLE IF NOT EXISTS DR_HOLDBACK_MAP (
-                              id            BIGINT PRIMARY KEY,
-                              content_range_from INTEGER NOT NULL,
-                              content_range_to INTEGER NOT NULL,
-                              form_range_from INTEGER NOT NULL,
-                              form_range_to INTEGER NOT NULL,
-                              dr_holdback_id   VARCHAR(32) references DR_HOLDBACK_RULES(id)
+    id            BIGINT PRIMARY KEY,
+    content_range_from INTEGER NOT NULL,
+    content_range_to INTEGER NOT NULL,
+    form_range_from INTEGER NOT NULL,
+    form_range_to INTEGER NOT NULL,
+    dr_holdback_id   VARCHAR(32) references DR_HOLDBACK_RULES(id)
 );
 
 CREATE TABLE IF NOT EXISTS AUDITLOG (
-                                        MILLIS BIGINT PRIMARY KEY,
-                                        USERNAME VARCHAR(256) NOT NULL,
-                                        CHANGETYPE VARCHAR(256) NOT NULL,
-                                        OBJECTNAME VARCHAR(256) NOT NULL,
-                                        TEXTBEFORE VARCHAR(65535) NOT NULL,
-                                        TEXTAFTER VARCHAR(65535) NOT NULL
+    MILLIS BIGINT PRIMARY KEY,
+    USERNAME VARCHAR(256) NOT NULL,
+    CHANGETYPE VARCHAR(256) NOT NULL,
+    OBJECTNAME VARCHAR(256) NOT NULL,
+    TEXTBEFORE VARCHAR(65535) NOT NULL,
+    TEXTAFTER VARCHAR(65535) NOT NULL
 );
 

--- a/src/test/resources/ddl/rightsmodule_create_h2_unittest.ddl
+++ b/src/test/resources/ddl/rightsmodule_create_h2_unittest.ddl
@@ -1,12 +1,14 @@
 CREATE TABLE IF NOT EXISTS RESTRICTED_IDS (
-                         id BIGINT PRIMARY KEY,
-                         id_value VARCHAR(256) NOT NULL,
-                         id_type VARCHAR(32) NOT NULL,
-                         platform VARCHAR(32),
-                         comment VARCHAR(16384),
-                         modified_by VARCHAR(256),
-                         modified_time BIGINT,
-                         modified_time_human VARCHAR(256)
+    id BIGINT PRIMARY KEY,
+    id_value VARCHAR(256) NOT NULL,
+    id_type VARCHAR(32) NOT NULL,
+    platform VARCHAR(32),
+    comment VARCHAR(16384),
+    created_by VARCHAR(256),
+    created_time BIGINT,
+    modified_by VARCHAR(256),
+    modified_time BIGINT,
+    modified_time_human VARCHAR(256)
 );
 
 CREATE UNIQUE INDEX IF NOT EXISTS unique_restricted_id ON RESTRICTED_IDS (id_value,id_type,platform);


### PR DESCRIPTION
I rettighedsmodulet (ds-license) har vi behov for en created_at og created_by attribut, når der oprettes en klausulering.

Attributterne created_at og created_by skal tilføjes i databasen og API’et, således at frontenden kan vise, hvem der har oprettet klausuleringen og tidspunktet. Man skal aldrig kunne ændre på disse værdier.
De skal også bruges til rapporteringsstatistik for rettighedshaverne (CopyDan).