### PR TITLE
Oauth on all methods except  /rights/calculate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Deleted API request to delete multiple restricted IDs
 - Moved storage method that is only used by unit tests to a storage subclass used by unittest. The methods are very destructive such as clearing all tables.
+- OAuth enabled on all methods except  /rights/calculate (and monitor  methods). In Ingest(write) environment OAuth must be enabled for ds-license as well, since new ds-license-web calls methods that modifies configuration in the database. All calls are logged in the audit log with username from Oauth token.
+
 
 ### Fixed
 

--- a/src/main/openapi/ds-license-openapi_v1.yaml
+++ b/src/main/openapi/ds-license-openapi_v1.yaml
@@ -706,12 +706,14 @@ paths:
             'application/json':
               schema:
                 type: string
+  
   /rights/calculate:
     post:
       tags:
         - 'DsRights'
       operationId: calculateRights
       summary: "Calculate restrictions for a record based on input values"
+#     No Oauth. Only called by system calls when indexing and no oauth is used system2system in ingest(write) environment.
       requestBody:
         required: true
         content:


### PR DESCRIPTION
Oauth on all methods except  /rights/calculate

Since this method is called by indexing workflow.

Merge into release_v2