### PR TITLE
New API method (/audit/auditEntries) to list AuditLogEntries by modifiedTime and

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -  Changed 'og' -> '&' in holdback category names
 
 ### Added
-- New API method (/audit/list) to list AuditLogEntries by modifiedTime and ObjectTypeEnum.
+- New API method (/audit/auditEntries) to list AuditLogEntries by modifiedTime and ObjectTypeEnum.
 
 ## [4.0.3](https://github.com/kb-dk/ds-license/releases/tag/ds-license-4.0.3) 2026-02-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to ds-license will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [Unreleased]
+
+### Added
+- New API method (/audit/list) to list AuditLogEntries by modifiedTime and ObjectTypeEnum.
+
 ## [4.0.3](https://github.com/kb-dk/ds-license/releases/tag/ds-license-4.0.3) 2026-02-16
 
 ### Changed

--- a/src/main/java/dk/kb/license/api/v1/impl/DsAuditApiServiceImpl.java
+++ b/src/main/java/dk/kb/license/api/v1/impl/DsAuditApiServiceImpl.java
@@ -47,12 +47,12 @@ public class DsAuditApiServiceImpl extends ImplBase implements DsAuditApi {
     }
 
     @Override
-    public List<AuditLogEntryOutputDto> getAuditLogOlderThanModifiedTime(Long modifiedTimeStart, ObjectTypeEnumDto type) {      
+    public List<AuditLogEntryOutputDto> getAuditLogOlderThanModifiedTime(Long modifiedTimeStart, ObjectTypeEnumDto changeName) {      
         if (modifiedTimeStart == null) {
             modifiedTimeStart = System.currentTimeMillis();
         }        
         try {
-            return AuditLogModuleFacade.getAuditLogList(modifiedTimeStart, type);
+            return AuditLogModuleFacade.getAuditLogOlderThanModifiedTime(modifiedTimeStart, changeName);
         } catch (Exception e) {
             throw handleException(e);
         }

--- a/src/main/java/dk/kb/license/api/v1/impl/DsAuditApiServiceImpl.java
+++ b/src/main/java/dk/kb/license/api/v1/impl/DsAuditApiServiceImpl.java
@@ -3,6 +3,8 @@ package dk.kb.license.api.v1.impl;
 import dk.kb.license.api.v1.*;
 
 import dk.kb.license.model.v1.AuditLogEntryOutputDto;
+import dk.kb.license.model.v1.ChangeTypeEnumDto;
+import dk.kb.license.model.v1.ObjectTypeEnumDto;
 
 import java.util.List;
 
@@ -43,4 +45,17 @@ public class DsAuditApiServiceImpl extends ImplBase implements DsAuditApi {
             throw handleException(e);
         }
     }
+
+    @Override
+    public List<AuditLogEntryOutputDto> getAuditLogList(Long modifiedTime, ObjectTypeEnumDto type) {      
+        if (modifiedTime == null) {
+            modifiedTime = System.currentTimeMillis();
+        }        
+        try {
+            return AuditLogModuleFacade.getAuditLogList(modifiedTime, type);
+        } catch (Exception e) {
+            throw handleException(e);
+        }
+    }
+   
 }

--- a/src/main/java/dk/kb/license/api/v1/impl/DsAuditApiServiceImpl.java
+++ b/src/main/java/dk/kb/license/api/v1/impl/DsAuditApiServiceImpl.java
@@ -47,12 +47,12 @@ public class DsAuditApiServiceImpl extends ImplBase implements DsAuditApi {
     }
 
     @Override
-    public List<AuditLogEntryOutputDto> getAuditLogList(Long modifiedTime, ObjectTypeEnumDto type) {      
-        if (modifiedTime == null) {
-            modifiedTime = System.currentTimeMillis();
+    public List<AuditLogEntryOutputDto> getAuditLogOlderThanModifiedTime(Long modifiedTimeStart, ObjectTypeEnumDto type) {      
+        if (modifiedTimeStart == null) {
+            modifiedTimeStart = System.currentTimeMillis();
         }        
         try {
-            return AuditLogModuleFacade.getAuditLogList(modifiedTime, type);
+            return AuditLogModuleFacade.getAuditLogList(modifiedTimeStart, type);
         } catch (Exception e) {
             throw handleException(e);
         }

--- a/src/main/java/dk/kb/license/facade/AuditLogModuleFacade.java
+++ b/src/main/java/dk/kb/license/facade/AuditLogModuleFacade.java
@@ -19,7 +19,7 @@ public class AuditLogModuleFacade {
      * @return the AuditLogEntry with the given id
      */
     public static AuditLogEntryOutputDto getAuditEntryById(Long auditLogId) {
-        return BaseModuleStorage.performStorageAction("getAuditEntries()", AuditLogModuleStorage.class, storage -> {
+        return BaseModuleStorage.performStorageAction("getAuditEntryById()", AuditLogModuleStorage.class, storage -> {
             return ((AuditLogModuleStorage) storage).getAuditLogById(auditLogId);
         });
     }
@@ -34,7 +34,7 @@ public class AuditLogModuleFacade {
      * @return List<AuditLogEntryOutputDto> with a maximum of 100 elements in the list. 
      */
     public static List<AuditLogEntryOutputDto> getAuditLogOlderThanModifiedTime(Long modifiedTimeStart, ObjectTypeEnumDto changeName) {                                  
-        return BaseModuleStorage.performStorageAction("getAuditLogList()", AuditLogModuleStorage.class, storage -> {
+        return BaseModuleStorage.performStorageAction("getAuditLogOlderThanModifiedTime()", AuditLogModuleStorage.class, storage -> {
          if (changeName == null) {
              return ((AuditLogModuleStorage) storage).getAuditLogOlderThanModifiedTimeListAll(modifiedTimeStart);     
          }

--- a/src/main/java/dk/kb/license/facade/AuditLogModuleFacade.java
+++ b/src/main/java/dk/kb/license/facade/AuditLogModuleFacade.java
@@ -1,6 +1,7 @@
 package dk.kb.license.facade;
 
 import dk.kb.license.model.v1.AuditLogEntryOutputDto;
+import dk.kb.license.model.v1.ObjectTypeEnumDto;
 import dk.kb.license.storage.AuditLogEntry;
 import dk.kb.license.storage.AuditLogModuleStorage;
 import dk.kb.license.storage.BaseModuleStorage;
@@ -23,6 +24,21 @@ public class AuditLogModuleFacade {
         });
     }
 
+    /**
+     * Retrieves List of {@link AuditLogEntry} . Maximum elements is 100. Use modifiedTimeStart for pagination.
+     * AuditLogEntries in the list are sorted by modifiedtime desc, so latest will come first in the list.     
+     *      
+     * @param modifiedTimeStart Will extract AuditLogEntries with modifiedtime less than this value
+     * @param type Optional, list only AuditLogEntries of this type. Will list all types if type is null
+     * 
+     * @return List<AuditLogEntryOutputDto> with a maximum of 100 elements in the list. 
+     */
+    public static List<AuditLogEntryOutputDto> getAuditLogList(Long modifiedTimeStart, ObjectTypeEnumDto type) {                                  
+        return BaseModuleStorage.performStorageAction("getAuditLogList()", AuditLogModuleStorage.class, storage -> {
+            return ((AuditLogModuleStorage) storage).getAuditLogList(modifiedTimeStart, type);
+        });
+    }
+    
     /**
      * Retrieves a list of all {@link AuditLogEntry} related to a given object.
      *

--- a/src/main/java/dk/kb/license/facade/AuditLogModuleFacade.java
+++ b/src/main/java/dk/kb/license/facade/AuditLogModuleFacade.java
@@ -26,16 +26,21 @@ public class AuditLogModuleFacade {
 
     /**
      * Retrieves List of {@link AuditLogEntry} . Maximum elements is 100. Use modifiedTimeStart for pagination.
-     * AuditLogEntries in the list are sorted by modifiedtime desc, so latest will come first in the list.     
+     * AuditLogEntries in the list are sorted by modifiedTimeStart desc, so latest will come first in the list.     
      *      
-     * @param modifiedTimeStart Will extract AuditLogEntries with modifiedtime less than this value
+     * @param modifiedTimeStart Will extract AuditLogEntries with modifiedTimeStart less than this value
      * @param type Optional, list only AuditLogEntries of this type. Will list all types if type is null
      * 
      * @return List<AuditLogEntryOutputDto> with a maximum of 100 elements in the list. 
      */
     public static List<AuditLogEntryOutputDto> getAuditLogList(Long modifiedTimeStart, ObjectTypeEnumDto type) {                                  
         return BaseModuleStorage.performStorageAction("getAuditLogList()", AuditLogModuleStorage.class, storage -> {
-            return ((AuditLogModuleStorage) storage).getAuditLogList(modifiedTimeStart, type);
+         if (type == null) {
+             return ((AuditLogModuleStorage) storage).getAuditLogListAll(modifiedTimeStart);     
+         }
+         else {
+             return ((AuditLogModuleStorage) storage).getAuditLogListByType(modifiedTimeStart,type);
+         }        
         });
     }
     

--- a/src/main/java/dk/kb/license/facade/AuditLogModuleFacade.java
+++ b/src/main/java/dk/kb/license/facade/AuditLogModuleFacade.java
@@ -29,17 +29,17 @@ public class AuditLogModuleFacade {
      * AuditLogEntries in the list are sorted by modifiedTimeStart desc, so latest will come first in the list.     
      *      
      * @param modifiedTimeStart Will extract AuditLogEntries with modifiedTimeStart less than this value
-     * @param type Optional, list only AuditLogEntries of this type. Will list all types if type is null
+     * @param changeName list only AuditLogEntries of this type. Will list all types if type is null.
      * 
      * @return List<AuditLogEntryOutputDto> with a maximum of 100 elements in the list. 
      */
-    public static List<AuditLogEntryOutputDto> getAuditLogList(Long modifiedTimeStart, ObjectTypeEnumDto type) {                                  
+    public static List<AuditLogEntryOutputDto> getAuditLogOlderThanModifiedTime(Long modifiedTimeStart, ObjectTypeEnumDto changeName) {                                  
         return BaseModuleStorage.performStorageAction("getAuditLogList()", AuditLogModuleStorage.class, storage -> {
-         if (type == null) {
-             return ((AuditLogModuleStorage) storage).getAuditLogListAll(modifiedTimeStart);     
+         if (changeName == null) {
+             return ((AuditLogModuleStorage) storage).getAuditLogOlderThanModifiedTimeListAll(modifiedTimeStart);     
          }
          else {
-             return ((AuditLogModuleStorage) storage).getAuditLogListByType(modifiedTimeStart,type);
+             return ((AuditLogModuleStorage) storage).getAuditLogOlderThanModifiedTimeListByType(modifiedTimeStart,changeName);
          }        
         });
     }

--- a/src/main/java/dk/kb/license/storage/AuditLogModuleStorage.java
+++ b/src/main/java/dk/kb/license/storage/AuditLogModuleStorage.java
@@ -97,7 +97,7 @@ public class AuditLogModuleStorage extends BaseModuleStorage {
    public List<AuditLogEntryOutputDto> getAuditLogOlderThanModifiedTimeListAll(Long modifiedTimeStart) throws IllegalArgumentException, SQLException {
        log.debug("getAuditLogOlderThanModifiedTimeListAll called for modifiedTimeStart='{}', type='{}'", modifiedTimeStart);
        
-       ArrayList<AuditLogEntryOutputDto> auditLogList = new ArrayList<AuditLogEntryOutputDto>();
+       List<AuditLogEntryOutputDto> auditLogList = new ArrayList<AuditLogEntryOutputDto>();
         
         //two different versions. Last also has type parameter.        
        
@@ -124,18 +124,18 @@ public class AuditLogModuleStorage extends BaseModuleStorage {
     * 
     * @return List<AuditLogEntryOutputDto> with a maximum of 100 elements in the list. 
     */
-  public List<AuditLogEntryOutputDto> getAuditLogOlderThanModifiedTimeListByType(Long modifiedTimeStart, ObjectTypeEnumDto type) throws IllegalArgumentException, SQLException {
-      if (type== null) {
+  public List<AuditLogEntryOutputDto> getAuditLogOlderThanModifiedTimeListByType(Long modifiedTimeStart, ObjectTypeEnumDto changeName) throws IllegalArgumentException, SQLException {
+      if (changeName == null) {
           throw new InvalidArgumentServiceException("ObjectTypeEnum must not be null");
       }
       
-      log.debug("getAuditLogOlderThanModifiedTimeListByType called for modifiedTimeStart='{}', type='{}'",modifiedTimeStart ,type);
+      log.debug("getAuditLogOlderThanModifiedTimeListByType called for modifiedTimeStart='{}', type='{}'",modifiedTimeStart ,changeName);
       
       ArrayList<AuditLogEntryOutputDto> auditLogList = new ArrayList<AuditLogEntryOutputDto>();              
       
       try (PreparedStatement stmt = connection.prepareStatement(selectAuditLogOlderThanModifiedTimeByChangeNameQuery);) {
           stmt.setLong(1, modifiedTimeStart);        
-          stmt.setString(2, type.getValue());                   
+          stmt.setString(2,changeName.getValue());                   
           ResultSet rs = stmt.executeQuery();
           while (rs.next()) { // maximum one due to unique/primary key constraint              
                AuditLogEntryOutputDto audit = auditLogEntryOutputDtoMapper.map(rs);

--- a/src/main/java/dk/kb/license/storage/AuditLogModuleStorage.java
+++ b/src/main/java/dk/kb/license/storage/AuditLogModuleStorage.java
@@ -98,9 +98,7 @@ public class AuditLogModuleStorage extends BaseModuleStorage {
        log.debug("getAuditLogOlderThanModifiedTimeListAll called for modifiedTimeStart='{}', type='{}'", modifiedTimeStart);
        
        List<AuditLogEntryOutputDto> auditLogList = new ArrayList<AuditLogEntryOutputDto>();
-        
-        //two different versions. Last also has type parameter.        
-       
+                       
        try (PreparedStatement stmt = connection.prepareStatement(selectAuditLogOlderThanModifiedTimeQuery);) {
            stmt.setLong(1, modifiedTimeStart);                     
            ResultSet rs = stmt.executeQuery();
@@ -131,7 +129,7 @@ public class AuditLogModuleStorage extends BaseModuleStorage {
       
       log.debug("getAuditLogOlderThanModifiedTimeListByType called for modifiedTimeStart='{}', type='{}'",modifiedTimeStart ,changeName);
       
-      ArrayList<AuditLogEntryOutputDto> auditLogList = new ArrayList<AuditLogEntryOutputDto>();              
+      List<AuditLogEntryOutputDto> auditLogList = new ArrayList<AuditLogEntryOutputDto>();              
       
       try (PreparedStatement stmt = connection.prepareStatement(selectAuditLogOlderThanModifiedTimeByChangeNameQuery);) {
           stmt.setLong(1, modifiedTimeStart);        

--- a/src/main/java/dk/kb/license/storage/AuditLogModuleStorage.java
+++ b/src/main/java/dk/kb/license/storage/AuditLogModuleStorage.java
@@ -2,6 +2,7 @@ package dk.kb.license.storage;
 
 import dk.kb.license.mapper.AuditLogEntryOutputDtoMapper;
 import dk.kb.license.model.v1.AuditLogEntryOutputDto;
+import dk.kb.license.model.v1.ObjectTypeEnumDto;
 import dk.kb.license.webservice.KBAuthorizationInterceptor;
 import org.apache.cxf.jaxrs.utils.JAXRSUtils;
 import org.apache.cxf.message.Message;
@@ -23,33 +24,37 @@ public class AuditLogModuleStorage extends BaseModuleStorage {
     private static final AuditLogEntryOutputDtoMapper auditLogEntryOutputDtoMapper = new AuditLogEntryOutputDtoMapper();
 
     //AUDITLOG
-    private static final String AUDITLOG_TABLE = "AUDITLOG";
-    private static final String AUDITLOG_ID_COLUMN = "ID";
-    private static final String AUDITLOG_OBJECTID_COLUMN = "OBJECTID";
-    private static final String AUDITLOG_MODIFIEDTIME_COLUMN = "MODIFIEDTIME";
-    private static final String AUDITLOG_USERNAME_COLUMN = "USERNAME";
-    private static final String AUDITLOG_CHANGETYPE_COLUMN = "CHANGETYPE";
-    private static final String AUDITLOG_CHANGENAME_COLUMN = "CHANGENAME";
-    private static final String AUDITLOG_IDENTIFIER_COLUMN = "IDENTIFIER";
-    private static final String AUDITLOG_CHANGECOMMENT_COLUMN = "CHANGECOMMENT";
-    private static final String AUDITLOG_TEXTBEFORE_COLUMN = "TEXTBEFORE";
-    private static final String AUDITLOG_TEXTAFTER_COLUMN = "TEXTAFTER";
+    private static final String TABLE = "AUDITLOG";
+    private static final String ID_COLUMN = "ID";
+    private static final String OBJECTID_COLUMN = "OBJECTID";
+    private static final String MODIFIEDTIME_COLUMN = "MODIFIEDTIME";
+    private static final String USERNAME_COLUMN = "USERNAME";
+    private static final String CHANGETYPE_COLUMN = "CHANGETYPE";
+    private static final String CHANGENAME_COLUMN = "CHANGENAME";
+    private static final String IDENTIFIER_COLUMN = "IDENTIFIER";
+    private static final String CHANGECOMMENT_COLUMN = "CHANGECOMMENT";
+    private static final String TEXTBEFORE_COLUMN = "TEXTBEFORE";
+    private static final String TEXTAFTER_COLUMN = "TEXTAFTER";
 
-    private final static String selectAuditLogQueryById = "SELECT * FROM " + AUDITLOG_TABLE + " WHERE " + AUDITLOG_ID_COLUMN + " = ? ";
-    private final static String selectAuditLogQueryByObjectId = "SELECT * FROM " + AUDITLOG_TABLE + " WHERE " + AUDITLOG_OBJECTID_COLUMN + " = ? " + " ORDER BY " + AUDITLOG_MODIFIEDTIME_COLUMN + " DESC";
+    
+    private final static String selectAuditLogListAllQuery    = "SELECT * FROM " + TABLE + " WHERE " + MODIFIEDTIME_COLUMN + " < ?  ORDER BY "+MODIFIEDTIME_COLUMN + " DESC LIMIT  100";
+    private final static String selectAuditLogListByTypeQuery = "SELECT * FROM " + TABLE + " WHERE " + MODIFIEDTIME_COLUMN + " < ?  AND "+ CHANGENAME_COLUMN+ " = ? ORDER BY " + MODIFIEDTIME_COLUMN + " DESC LIMIT 100";
+  
+    private final static String selectAuditLogQueryById = "SELECT * FROM " + TABLE + " WHERE " + ID_COLUMN + " = ? ";
+    private final static String selectAuditLogQueryByObjectId = "SELECT * FROM " + TABLE + " WHERE " + OBJECTID_COLUMN + " = ? " + " ORDER BY " + MODIFIEDTIME_COLUMN + " DESC";
 
-    private final static String selectAllAuditLogQuery = "SELECT * FROM " + AUDITLOG_TABLE + " ORDER BY " + AUDITLOG_MODIFIEDTIME_COLUMN + " DESC";
-    private final static String persistAuditLog = "INSERT INTO " + AUDITLOG_TABLE + " (" +
-            AUDITLOG_ID_COLUMN + ", " +
-            AUDITLOG_OBJECTID_COLUMN + ", " +
-            AUDITLOG_MODIFIEDTIME_COLUMN + ", " +
-            AUDITLOG_USERNAME_COLUMN + ", " +
-            AUDITLOG_CHANGETYPE_COLUMN + ", " +
-            AUDITLOG_CHANGENAME_COLUMN + ", " +
-            AUDITLOG_IDENTIFIER_COLUMN + ", " +
-            AUDITLOG_CHANGECOMMENT_COLUMN + ", " +
-            AUDITLOG_TEXTBEFORE_COLUMN + ", " +
-            AUDITLOG_TEXTAFTER_COLUMN + ") " +
+    private final static String selectAllAuditLogQuery = "SELECT * FROM " + TABLE + " ORDER BY " + MODIFIEDTIME_COLUMN + " DESC";
+    private final static String persistAuditLog = "INSERT INTO " + TABLE + " (" +
+            ID_COLUMN + ", " +
+            OBJECTID_COLUMN + ", " +
+            MODIFIEDTIME_COLUMN + ", " +
+            USERNAME_COLUMN + ", " +
+            CHANGETYPE_COLUMN + ", " +
+            CHANGENAME_COLUMN + ", " +
+            IDENTIFIER_COLUMN + ", " +
+            CHANGECOMMENT_COLUMN + ", " +
+            TEXTBEFORE_COLUMN + ", " +
+            TEXTAFTER_COLUMN + ") " +
             "VALUES (?,?,?,?,?,?,?,?,?,?)"; // #|?|=10
 
     public AuditLogModuleStorage() throws SQLException {
@@ -78,6 +83,47 @@ public class AuditLogModuleStorage extends BaseModuleStorage {
         }
     }
 
+    /**
+     * Retrieves List of {@link AuditLogEntry} . Maximum elements is 100. Use modifiedTimeStart for pagination.
+     * AuditLogEntries in the list are sorted by modifiedtime desc, so latest will come first in the list.     
+     *      
+     * @param modifiedTimeStart Will extract AuditLogEntries with modifiedtime less than this value
+     * @param type Optional, list only AuditLogEntries of this type. Will list all types if type is null
+     * 
+     * @return List<AuditLogEntryOutputDto> with a maximum of 100 elements in the list. 
+     */
+   public ArrayList<AuditLogEntryOutputDto> getAuditLogList(long modifiedTimeStart, ObjectTypeEnumDto type) throws IllegalArgumentException, SQLException {
+       log.debug("AuditlogList called for modifiedTimeStart='{}', type='{}'",modifiedTimeStart ,type);
+       
+       ArrayList<AuditLogEntryOutputDto> auditLogList = new ArrayList<AuditLogEntryOutputDto>();
+        
+        //two different versions. Last also has type parameter.
+        String selectStatement = null;       
+        if (type == null) {
+            selectStatement = selectAuditLogListAllQuery;
+        }
+        else {
+            selectStatement = selectAuditLogListByTypeQuery;
+        }
+       
+       try (PreparedStatement stmt = connection.prepareStatement(selectStatement);) {
+           stmt.setLong(1, modifiedTimeStart);
+           if(type != null) {
+             stmt.setString(2, type.getValue());
+           }           
+           ResultSet rs = stmt.executeQuery();
+           while (rs.next()) { // maximum one due to unique/primary key constraint              
+                AuditLogEntryOutputDto audit = auditLogEntryOutputDtoMapper.map(rs);
+                auditLogList.add(audit);
+           }       
+           return auditLogList;
+       } catch (SQLException e) {
+           log.error("SQL Exception in getAuditLogList: " + e.getMessage());
+           throw e;
+       }
+   }
+
+    
     /**
      * @param objectId The ID for the object extract audit log.
      * @return List of AuditLog objects. Will return empty list if objectId is not found.

--- a/src/main/java/dk/kb/license/storage/AuditLogModuleStorage.java
+++ b/src/main/java/dk/kb/license/storage/AuditLogModuleStorage.java
@@ -127,7 +127,7 @@ public class AuditLogModuleStorage extends BaseModuleStorage {
           throw new InvalidArgumentServiceException("ObjectTypeEnum must not be null");
       }
       
-      log.debug("getAuditLogOlderThanModifiedTimeListByType called for modifiedTimeStart='{}', type='{}'",modifiedTimeStart ,changeName);
+      log.debug("getAuditLogOlderThanModifiedTimeListByType called for modifiedTimeStart='{}', changeName='{}'",modifiedTimeStart ,changeName);
       
       List<AuditLogEntryOutputDto> auditLogList = new ArrayList<AuditLogEntryOutputDto>();              
       

--- a/src/main/java/dk/kb/license/storage/AuditLogModuleStorage.java
+++ b/src/main/java/dk/kb/license/storage/AuditLogModuleStorage.java
@@ -4,6 +4,8 @@ import dk.kb.license.mapper.AuditLogEntryOutputDtoMapper;
 import dk.kb.license.model.v1.AuditLogEntryOutputDto;
 import dk.kb.license.model.v1.ObjectTypeEnumDto;
 import dk.kb.license.webservice.KBAuthorizationInterceptor;
+import dk.kb.util.webservice.exception.InvalidArgumentServiceException;
+
 import org.apache.cxf.jaxrs.utils.JAXRSUtils;
 import org.apache.cxf.message.Message;
 import org.keycloak.representations.AccessToken;
@@ -14,6 +16,7 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Class for handling the audit log entries.
@@ -35,10 +38,9 @@ public class AuditLogModuleStorage extends BaseModuleStorage {
     private static final String CHANGECOMMENT_COLUMN = "CHANGECOMMENT";
     private static final String TEXTBEFORE_COLUMN = "TEXTBEFORE";
     private static final String TEXTAFTER_COLUMN = "TEXTAFTER";
-
     
-    private final static String selectAuditLogListAllQuery    = "SELECT * FROM " + TABLE + " WHERE " + MODIFIEDTIME_COLUMN + " < ?  ORDER BY "+MODIFIEDTIME_COLUMN + " DESC LIMIT  100";
-    private final static String selectAuditLogListByTypeQuery = "SELECT * FROM " + TABLE + " WHERE " + MODIFIEDTIME_COLUMN + " < ?  AND "+ CHANGENAME_COLUMN+ " = ? ORDER BY " + MODIFIEDTIME_COLUMN + " DESC LIMIT 100";
+    private final static String selectAuditLogOlderThanModifiedTimeQuery    = "SELECT * FROM " + TABLE + " WHERE " + MODIFIEDTIME_COLUMN + " < ? ORDER BY "+MODIFIEDTIME_COLUMN + " DESC LIMIT 100";
+    private final static String selectAuditLogOlderThanModifiedTimeByTypeQuery          = "SELECT * FROM " + TABLE + " WHERE " + MODIFIEDTIME_COLUMN + " < ? AND "+ CHANGENAME_COLUMN + " = ? ORDER BY " + MODIFIEDTIME_COLUMN + " DESC LIMIT 100";
   
     private final static String selectAuditLogQueryById = "SELECT * FROM " + TABLE + " WHERE " + ID_COLUMN + " = ? ";
     private final static String selectAuditLogQueryByObjectId = "SELECT * FROM " + TABLE + " WHERE " + OBJECTID_COLUMN + " = ? " + " ORDER BY " + MODIFIEDTIME_COLUMN + " DESC";
@@ -88,29 +90,18 @@ public class AuditLogModuleStorage extends BaseModuleStorage {
      * AuditLogEntries in the list are sorted by modifiedtime desc, so latest will come first in the list.     
      *      
      * @param modifiedTimeStart Will extract AuditLogEntries with modifiedtime less than this value
-     * @param type Optional, list only AuditLogEntries of this type. Will list all types if type is null
      * 
      * @return List<AuditLogEntryOutputDto> with a maximum of 100 elements in the list. 
      */
-   public ArrayList<AuditLogEntryOutputDto> getAuditLogList(long modifiedTimeStart, ObjectTypeEnumDto type) throws IllegalArgumentException, SQLException {
-       log.debug("AuditlogList called for modifiedTimeStart='{}', type='{}'",modifiedTimeStart ,type);
+   public List<AuditLogEntryOutputDto> getAuditLogListAll(Long modifiedTimeStart) throws IllegalArgumentException, SQLException {
+       log.debug("AuditlogList called for modifiedTimeStart='{}', type='{}'",modifiedTimeStart);
        
        ArrayList<AuditLogEntryOutputDto> auditLogList = new ArrayList<AuditLogEntryOutputDto>();
         
-        //two different versions. Last also has type parameter.
-        String selectStatement = null;       
-        if (type == null) {
-            selectStatement = selectAuditLogListAllQuery;
-        }
-        else {
-            selectStatement = selectAuditLogListByTypeQuery;
-        }
+        //two different versions. Last also has type parameter.        
        
-       try (PreparedStatement stmt = connection.prepareStatement(selectStatement);) {
-           stmt.setLong(1, modifiedTimeStart);
-           if(type != null) {
-             stmt.setString(2, type.getValue());
-           }           
+       try (PreparedStatement stmt = connection.prepareStatement(selectAuditLogOlderThanModifiedTimeQuery);) {
+           stmt.setLong(1, modifiedTimeStart);                     
            ResultSet rs = stmt.executeQuery();
            while (rs.next()) { // maximum one due to unique/primary key constraint              
                 AuditLogEntryOutputDto audit = auditLogEntryOutputDtoMapper.map(rs);
@@ -123,6 +114,43 @@ public class AuditLogModuleStorage extends BaseModuleStorage {
        }
    }
 
+   
+   /**
+    * Retrieves List of {@link AuditLogEntry} . Maximum elements is 100. Use modifiedTimeStart for pagination.
+    * AuditLogEntries in the list are sorted by modifiedtime desc, so latest will come first in the list.     
+    *      
+    * @param modifiedTimeStart Will extract AuditLogEntries with modifiedtime less than this value
+    * @param type Optional, list only AuditLogEntries of this type. Will list all types if type is null
+    * 
+    * @return List<AuditLogEntryOutputDto> with a maximum of 100 elements in the list. 
+    */
+  public List<AuditLogEntryOutputDto> getAuditLogListByType(Long modifiedTimeStart, ObjectTypeEnumDto type) throws IllegalArgumentException, SQLException {
+      if (type== null) {
+          throw new InvalidArgumentServiceException("ObjectTypeEnum must not be null");
+      }
+      
+      log.debug("AuditlogList called for modifiedTimeStart='{}', type='{}'",modifiedTimeStart ,type);
+      
+      ArrayList<AuditLogEntryOutputDto> auditLogList = new ArrayList<AuditLogEntryOutputDto>();              
+      
+      try (PreparedStatement stmt = connection.prepareStatement(selectAuditLogOlderThanModifiedTimeByTypeQuery);) {
+          stmt.setLong(1, modifiedTimeStart);
+          if(type != null) {
+            stmt.setString(2, type.getValue());
+          }           
+          ResultSet rs = stmt.executeQuery();
+          while (rs.next()) { // maximum one due to unique/primary key constraint              
+               AuditLogEntryOutputDto audit = auditLogEntryOutputDtoMapper.map(rs);
+               auditLogList.add(audit);
+          }       
+          return auditLogList;
+      } catch (SQLException e) {
+          log.error("SQL Exception in getAuditLogList: " + e.getMessage());
+          throw e;
+      }
+  }
+
+   
     
     /**
      * @param objectId The ID for the object extract audit log.

--- a/src/main/java/dk/kb/license/storage/AuditLogModuleStorage.java
+++ b/src/main/java/dk/kb/license/storage/AuditLogModuleStorage.java
@@ -39,8 +39,9 @@ public class AuditLogModuleStorage extends BaseModuleStorage {
     private static final String TEXTBEFORE_COLUMN = "TEXTBEFORE";
     private static final String TEXTAFTER_COLUMN = "TEXTAFTER";
     
+                                
     private final static String selectAuditLogOlderThanModifiedTimeQuery    = "SELECT * FROM " + TABLE + " WHERE " + MODIFIEDTIME_COLUMN + " < ? ORDER BY "+MODIFIEDTIME_COLUMN + " DESC LIMIT 100";
-    private final static String selectAuditLogOlderThanModifiedTimeByTypeQuery          = "SELECT * FROM " + TABLE + " WHERE " + MODIFIEDTIME_COLUMN + " < ? AND "+ CHANGENAME_COLUMN + " = ? ORDER BY " + MODIFIEDTIME_COLUMN + " DESC LIMIT 100";
+    private final static String selectAuditLogOlderThanModifiedTimeByChangeNameQuery          = "SELECT * FROM " + TABLE + " WHERE " + MODIFIEDTIME_COLUMN + " < ? AND "+ CHANGENAME_COLUMN + " = ? ORDER BY " + MODIFIEDTIME_COLUMN + " DESC LIMIT 100";
   
     private final static String selectAuditLogQueryById = "SELECT * FROM " + TABLE + " WHERE " + ID_COLUMN + " = ? ";
     private final static String selectAuditLogQueryByObjectId = "SELECT * FROM " + TABLE + " WHERE " + OBJECTID_COLUMN + " = ? " + " ORDER BY " + MODIFIEDTIME_COLUMN + " DESC";
@@ -93,8 +94,8 @@ public class AuditLogModuleStorage extends BaseModuleStorage {
      * 
      * @return List<AuditLogEntryOutputDto> with a maximum of 100 elements in the list. 
      */
-   public List<AuditLogEntryOutputDto> getAuditLogListAll(Long modifiedTimeStart) throws IllegalArgumentException, SQLException {
-       log.debug("AuditlogList called for modifiedTimeStart='{}', type='{}'",modifiedTimeStart);
+   public List<AuditLogEntryOutputDto> getAuditLogOlderThanModifiedTimeListAll(Long modifiedTimeStart) throws IllegalArgumentException, SQLException {
+       log.debug("getAuditLogOlderThanModifiedTimeListAll called for modifiedTimeStart='{}', type='{}'", modifiedTimeStart);
        
        ArrayList<AuditLogEntryOutputDto> auditLogList = new ArrayList<AuditLogEntryOutputDto>();
         
@@ -109,11 +110,10 @@ public class AuditLogModuleStorage extends BaseModuleStorage {
            }       
            return auditLogList;
        } catch (SQLException e) {
-           log.error("SQL Exception in getAuditLogList: " + e.getMessage());
+           log.error("SQL Exception in getAuditLogOlderThanModifiedTimeListAll " + e.getMessage());
            throw e;
        }
    }
-
    
    /**
     * Retrieves List of {@link AuditLogEntry} . Maximum elements is 100. Use modifiedTimeStart for pagination.
@@ -124,20 +124,18 @@ public class AuditLogModuleStorage extends BaseModuleStorage {
     * 
     * @return List<AuditLogEntryOutputDto> with a maximum of 100 elements in the list. 
     */
-  public List<AuditLogEntryOutputDto> getAuditLogListByType(Long modifiedTimeStart, ObjectTypeEnumDto type) throws IllegalArgumentException, SQLException {
+  public List<AuditLogEntryOutputDto> getAuditLogOlderThanModifiedTimeListByType(Long modifiedTimeStart, ObjectTypeEnumDto type) throws IllegalArgumentException, SQLException {
       if (type== null) {
           throw new InvalidArgumentServiceException("ObjectTypeEnum must not be null");
       }
       
-      log.debug("AuditlogList called for modifiedTimeStart='{}', type='{}'",modifiedTimeStart ,type);
+      log.debug("getAuditLogOlderThanModifiedTimeListByType called for modifiedTimeStart='{}', type='{}'",modifiedTimeStart ,type);
       
       ArrayList<AuditLogEntryOutputDto> auditLogList = new ArrayList<AuditLogEntryOutputDto>();              
       
-      try (PreparedStatement stmt = connection.prepareStatement(selectAuditLogOlderThanModifiedTimeByTypeQuery);) {
-          stmt.setLong(1, modifiedTimeStart);
-          if(type != null) {
-            stmt.setString(2, type.getValue());
-          }           
+      try (PreparedStatement stmt = connection.prepareStatement(selectAuditLogOlderThanModifiedTimeByChangeNameQuery);) {
+          stmt.setLong(1, modifiedTimeStart);        
+          stmt.setString(2, type.getValue());                   
           ResultSet rs = stmt.executeQuery();
           while (rs.next()) { // maximum one due to unique/primary key constraint              
                AuditLogEntryOutputDto audit = auditLogEntryOutputDtoMapper.map(rs);
@@ -145,7 +143,7 @@ public class AuditLogModuleStorage extends BaseModuleStorage {
           }       
           return auditLogList;
       } catch (SQLException e) {
-          log.error("SQL Exception in getAuditLogList: " + e.getMessage());
+          log.error("SQL Exception in getAuditLogOlderThanModifiedTimeListByType: " + e.getMessage());
           throw e;
       }
   }

--- a/src/main/openapi/ds-license-openapi_v1.yaml
+++ b/src/main/openapi/ds-license-openapi_v1.yaml
@@ -518,7 +518,41 @@ paths:
                 items:
                   $ref: '#/components/schemas/GroupType'
 
-  # Audit
+  # Audit  
+  /audit/list:
+    get:
+      tags:
+        - 'DsAudit'
+      summary: 'Return list of AuditLog entries. Parameters are modifiedTime and changeName, both are optional. Maximum returned is 100. Use modifiedTime for pagination'
+      operationId: getAuditLogList
+      security:
+        - KBOAuth:
+            - ds-license-readonly
+            - ds-license-admin
+      parameters:
+        - name: modifiedTime
+          in: query
+          description: 'List latest Auditlog entries less than modifiedTime. Will default to current time if modifiedTime is not set in request.'
+          schema:
+            type: integer
+            format: int64            
+        - name: changeName
+          in: query
+          description: 'List of auditlog entries of this changeName type. If null will return all changeName types.'
+          schema:
+            $ref: '#/components/schemas/ObjectTypeEnum'
+            nullable: true
+                                                         
+      responses:
+        '200':
+          description: 'List of AuditLogEntryOutput'
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/AuditLogEntryOutput'
+  
   /audit/auditEntryById:
     get:
       tags:
@@ -1749,7 +1783,7 @@ components:
           type: string
         textAfter:
           type: string
-
+  
     RestrictedIdInput:
       type: object
       required:
@@ -2160,7 +2194,8 @@ components:
           type: integer
           format: int32
           description: 'Number of records updated'
-
+          
+          
   securitySchemes:
     KBOAuth:
       type: oauth2

--- a/src/main/openapi/ds-license-openapi_v1.yaml
+++ b/src/main/openapi/ds-license-openapi_v1.yaml
@@ -1782,7 +1782,7 @@ components:
           type: string
         textAfter:
           type: string
-  
+
     RestrictedIdInput:
       type: object
       required:

--- a/src/main/openapi/ds-license-openapi_v1.yaml
+++ b/src/main/openapi/ds-license-openapi_v1.yaml
@@ -519,20 +519,20 @@ paths:
                   $ref: '#/components/schemas/GroupType'
 
   # Audit  
-  /audit/list:
+  /audit/auditEntries':
     get:
       tags:
         - 'DsAudit'
-      summary: 'Return list of AuditLog entries. Parameters are modifiedTime and changeName, both are optional. Maximum returned is 100. Use modifiedTime for pagination'
-      operationId: getAuditLogList
+      summary: 'Return list of AuditLog entries. Parameters are modifiedTimeStart and changeName, both are optional. Maximum returned is 100. Use modifiedTime for pagination'
+      operationId: getAuditLogOlderThanModifiedTime
       security:
         - KBOAuth:
             - ds-license-readonly
             - ds-license-admin
       parameters:
-        - name: modifiedTime
+        - name: modifiedTimeStart
           in: query
-          description: 'List latest Auditlog entries less than modifiedTime. Will default to current time if modifiedTime is not set in request.'
+          description: 'List latest Auditlog entries less than modifiedTimeStart. Will default to current time if modifiedTimeStart is not set in request.'
           schema:
             type: integer
             format: int64            
@@ -541,8 +541,7 @@ paths:
           description: 'List of auditlog entries of this changeName type. If null will return all changeName types.'
           schema:
             $ref: '#/components/schemas/ObjectTypeEnum'
-            nullable: true
-                                                         
+            nullable: true                                                        
       responses:
         '200':
           description: 'List of AuditLogEntryOutput'
@@ -552,7 +551,7 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/AuditLogEntryOutput'
-  
+
   /audit/auditEntryById:
     get:
       tags:
@@ -2194,8 +2193,7 @@ components:
           type: integer
           format: int32
           description: 'Number of records updated'
-          
-          
+                    
   securitySchemes:
     KBOAuth:
       type: oauth2

--- a/src/test/java/dk/kb/license/facade/AuditLogModuleFacadeTest.java
+++ b/src/test/java/dk/kb/license/facade/AuditLogModuleFacadeTest.java
@@ -23,7 +23,9 @@ import org.slf4j.LoggerFactory;
 
 import dk.kb.license.config.ServiceConfig;
 import dk.kb.license.model.v1.AuditLogEntryOutputDto;
+import dk.kb.license.model.v1.ChangeTypeEnumDto;
 import dk.kb.license.model.v1.DeleteReasonDto;
+import dk.kb.license.model.v1.ObjectTypeEnumDto;
 import dk.kb.license.storage.AuditLogModuleStorageForUnitTest;
 import dk.kb.license.storage.BaseModuleStorage;
 import dk.kb.license.storage.UnitTestUtil;
@@ -88,15 +90,18 @@ public class AuditLogModuleFacadeTest extends UnitTestUtil {
             deleteReasonDto.setChangeComment(changeComment);
 
             long presentationTypeId = LicenseModuleFacade.persistLicensePresentationType(key, value, valueEnglish, mockedSession);
-            
-            ArrayList<AuditLogEntryOutputDto> auditLogAll = storage.getAllAudit();
-
-            // Only valid RestrictedIdInputDto objects is in the audit log
+            long after=System.currentTimeMillis()+1;
+            //No type defined, get all.
+            List<AuditLogEntryOutputDto> auditLogAll= AuditLogModuleFacade.getAuditLogOlderThanModifiedTime(after,null);            
             assertEquals(1, auditLogAll.size());
-        }
+            
+            //The correct type just added
+            List<AuditLogEntryOutputDto> auditPresentationType= AuditLogModuleFacade.getAuditLogOlderThanModifiedTime(after,ObjectTypeEnumDto.PRESENTATION_TYPE);            
+            assertEquals(1, auditPresentationType.size()); //Found
 
-    }
-    
-    
-    
+            //Not the type added
+            List<AuditLogEntryOutputDto> dsIDType= AuditLogModuleFacade.getAuditLogOlderThanModifiedTime(after,ObjectTypeEnumDto.DS_ID);           
+            assertEquals(0, dsIDType.size()); //Not found            
+        }
+    }    
 }

--- a/src/test/java/dk/kb/license/facade/AuditLogModuleFacadeTest.java
+++ b/src/test/java/dk/kb/license/facade/AuditLogModuleFacadeTest.java
@@ -13,6 +13,7 @@ import javax.servlet.http.HttpSession;
 import org.apache.cxf.jaxrs.utils.JAXRSUtils;
 import org.apache.cxf.message.MessageImpl;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.keycloak.representations.AccessToken;
 import org.mockito.MockedStatic;
@@ -45,6 +46,27 @@ public class AuditLogModuleFacadeTest extends UnitTestUtil {
         H2DbUtil.createEmptyH2DBFromDDL(URL, DRIVER, USERNAME, PASSWORD, List.of("ddl/licensemodule_create_h2_unittest.ddl","ddl/audit_log_module_create_h2_unittest.ddl"));
         storage = new  AuditLogModuleStorageForUnitTest();               
     }
+    
+    /*
+     * Delete all records between each unittest. The clearTableRecords is only called from here.
+     * The facade class is responsible for committing transactions. So clean up between unittests.
+     */
+    @BeforeEach
+    public void beforeEach() throws SQLException {
+        ArrayList<String> tables = new ArrayList<>();
+        tables.add("PRESENTATIONTYPES");
+        tables.add("GROUPTYPES");
+        tables.add("ATTRIBUTETYPES");
+        tables.add("LICENSE");
+        tables.add("ATTRIBUTEGROUP");
+        tables.add("ATTRIBUTE");
+        tables.add("VALUE_ORG");
+        tables.add("LICENSECONTENT");    
+        tables.add("PRESENTATION");
+        tables.add("AUDITLOG");    
+        storage.clearTableRecords(tables);
+    }
+    
     
     @Test
     public void testAuditLogList() throws SQLException {

--- a/src/test/java/dk/kb/license/facade/AuditLogModuleFacadeTest.java
+++ b/src/test/java/dk/kb/license/facade/AuditLogModuleFacadeTest.java
@@ -1,0 +1,80 @@
+package dk.kb.license.facade;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mockStatic;
+
+import java.io.IOException;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.servlet.http.HttpSession;
+
+import org.apache.cxf.jaxrs.utils.JAXRSUtils;
+import org.apache.cxf.message.MessageImpl;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.keycloak.representations.AccessToken;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import dk.kb.license.config.ServiceConfig;
+import dk.kb.license.model.v1.AuditLogEntryOutputDto;
+import dk.kb.license.model.v1.DeleteReasonDto;
+import dk.kb.license.storage.AuditLogModuleStorageForUnitTest;
+import dk.kb.license.storage.BaseModuleStorage;
+import dk.kb.license.storage.UnitTestUtil;
+import dk.kb.license.util.H2DbUtil;
+import dk.kb.license.webservice.KBAuthorizationInterceptor;
+
+
+public class AuditLogModuleFacadeTest extends UnitTestUtil {
+
+
+    protected static AuditLogModuleStorageForUnitTest storage = null;
+    private static final Logger log = LoggerFactory.getLogger(AuditLogModuleFacadeTest.class);
+    static MockedStatic<JAXRSUtils> mocked;
+
+    @BeforeAll
+    public static void beforeClass() throws IOException, SQLException {
+        ServiceConfig.initialize("conf/ds-license*.yaml", "ds-license-integration-test.yaml");
+        BaseModuleStorage.initialize(DRIVER, URL, USERNAME, PASSWORD);
+        
+        H2DbUtil.createEmptyH2DBFromDDL(URL, DRIVER, USERNAME, PASSWORD, List.of("ddl/licensemodule_create_h2_unittest.ddl","ddl/audit_log_module_create_h2_unittest.ddl"));
+        storage = new  AuditLogModuleStorageForUnitTest();               
+    }
+    
+    @Test
+    public void testAuditLogList() throws SQLException {
+        HttpSession mockedSession = Mockito.mock(HttpSession.class);
+        Mockito.when(mockedSession.getAttribute("oauth_user")).thenReturn("mockedName");
+
+        MessageImpl message = new MessageImpl();
+        AccessToken mockedToken = Mockito.mock(AccessToken.class);
+        Mockito.when(mockedToken.getName()).thenReturn("mockedName");
+        message.put(KBAuthorizationInterceptor.ACCESS_TOKEN, mockedToken);
+        
+        try (MockedStatic<JAXRSUtils> mocked = mockStatic(JAXRSUtils.class)) {
+            mocked.when(JAXRSUtils::getCurrentMessage).thenReturn(message);
+            String key = "keyAuditTest";
+            String value = "unit_test_value";
+            String valueEnglish = "unit_test_value_en";
+            String changeComment = "changeComment";
+            DeleteReasonDto deleteReasonDto = new DeleteReasonDto();
+            deleteReasonDto.setChangeComment(changeComment);
+
+            long presentationTypeId = LicenseModuleFacade.persistLicensePresentationType(key, value, valueEnglish, mockedSession);
+            
+            ArrayList<AuditLogEntryOutputDto> auditLogAll = storage.getAllAudit();
+
+            // Only valid RestrictedIdInputDto objects is in the audit log
+            assertEquals(1, auditLogAll.size());
+        }
+
+    }
+    
+    
+    
+}

--- a/src/test/java/dk/kb/license/facade/LicenseModuleFacadeTest.java
+++ b/src/test/java/dk/kb/license/facade/LicenseModuleFacadeTest.java
@@ -11,6 +11,7 @@ import dk.kb.license.webservice.KBAuthorizationInterceptor;
 import org.apache.cxf.jaxrs.utils.JAXRSUtils;
 import org.apache.cxf.message.MessageImpl;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.keycloak.representations.AccessToken;
 import org.mockito.MockedStatic;
@@ -40,7 +41,27 @@ public class LicenseModuleFacadeTest extends UnitTestUtil {
         H2DbUtil.createEmptyH2DBFromDDL(URL, DRIVER, USERNAME, PASSWORD, List.of("ddl/licensemodule_create_h2_unittest.ddl", "ddl/audit_log_module_create_h2_unittest.ddl"));
         storage = new LicenseModuleStorageForUnitTest();
     }
-
+   
+    /*
+     * Delete all records between each unittest. The clearTableRecords is only called from here.
+     * The facade class is responsible for committing transactions. So clean up between unittests.
+     */
+    @BeforeEach
+    public void beforeEach() throws SQLException {
+        ArrayList<String> tables = new ArrayList<>();
+        tables.add("PRESENTATIONTYPES");
+        tables.add("GROUPTYPES");
+        tables.add("ATTRIBUTETYPES");
+        tables.add("LICENSE");
+        tables.add("ATTRIBUTEGROUP");
+        tables.add("ATTRIBUTE");
+        tables.add("VALUE_ORG");
+        tables.add("LICENSECONTENT");    
+        tables.add("PRESENTATION");
+        tables.add("AUDITLOG");    
+        storage.clearTableRecords(tables);
+    }
+    
     @Test
     public void testAuditLog() throws SQLException {
         HttpSession mockedSession = Mockito.mock(HttpSession.class);

--- a/src/test/java/dk/kb/license/storage/AuditLogModuleStorageTest.java
+++ b/src/test/java/dk/kb/license/storage/AuditLogModuleStorageTest.java
@@ -95,19 +95,45 @@ public class AuditLogModuleStorageTest extends UnitTestUtil {
             assertEquals(identifier, auditFromStorage.getIdentifier());
             assertEquals(changeComment, auditFromStorage.getChangeComment());
             assertEquals(textBefore, auditFromStorage.getTextBefore());
-            assertEquals(textAfter, auditFromStorage.getTextAfter());
-            
-            //list, all
-            ArrayList<AuditLogEntryOutputDto> auditLogList = storage.getAuditLogList(System.currentTimeMillis(), null);
-            assertEquals(1,auditLogList.size());
-            
-            //list DR_PRODUCTION_ID 
-            auditLogList = storage.getAuditLogList(System.currentTimeMillis(),ObjectTypeEnumDto.DR_PRODUCTION_ID);
-            assertEquals(1,auditLogList.size());
-            
-            //list LICENSE (no rows)
-            auditLogList = storage.getAuditLogList(System.currentTimeMillis(),ObjectTypeEnumDto.LICENSE);
-            assertEquals(0,auditLogList.size());            
+            assertEquals(textAfter, auditFromStorage.getTextAfter());                                 
         }
     }
+    
+    @Test
+    public void testListAuditLog() throws SQLException, IllegalArgumentException {
+        //Arrange
+        String userName = "mockedName";
+        MessageImpl message = new MessageImpl();
+        AccessToken mockedToken = Mockito.mock(AccessToken.class);
+        Mockito.when(mockedToken.getName()).thenReturn(userName);
+        message.put(KBAuthorizationInterceptor.ACCESS_TOKEN, mockedToken);
+
+        try (MockedStatic<JAXRSUtils> mocked = mockStatic(JAXRSUtils.class)) {
+            mocked.when(JAXRSUtils::getCurrentMessage).thenReturn(message);
+
+            Long objectId = 123456789L;
+            ChangeTypeEnumDto changeType = ChangeTypeEnumDto.UPDATE;
+            ObjectTypeEnumDto changeName = ObjectTypeEnumDto.DR_PRODUCTION_ID;
+            String identifier = "1234";
+            String changeComment = "changeComment";
+            String textBefore = "before";
+            String textAfter = "after";
+
+            AuditLogEntry auditLog = new AuditLogEntry(objectId, "", changeType, changeName, identifier, changeComment, textBefore, textAfter);
+            long auditLogId = storage.persistAuditLog(auditLog);
+            
+            long time=System.currentTimeMillis()+1L; //Need to add 1 to time since often it will happen in same millis in test and method is strict less than            
+            //list, all.  
+            List<AuditLogEntryOutputDto> auditLogList = storage.getAuditLogListAll(time);
+            assertEquals(1,auditLogList.size());
+
+            //list DR_PRODUCTION_ID 
+            auditLogList = storage.getAuditLogListByType(time,ObjectTypeEnumDto.DR_PRODUCTION_ID);
+            assertEquals(1,auditLogList.size());
+
+            //list LICENSE (no rows)
+            auditLogList = storage.getAuditLogListByType(time,ObjectTypeEnumDto.LICENSE);
+            assertEquals(0,auditLogList.size());
+        }
+    }   
 }

--- a/src/test/java/dk/kb/license/storage/AuditLogModuleStorageTest.java
+++ b/src/test/java/dk/kb/license/storage/AuditLogModuleStorageTest.java
@@ -124,15 +124,15 @@ public class AuditLogModuleStorageTest extends UnitTestUtil {
             
             long time=System.currentTimeMillis()+1L; //Need to add 1 to time since often it will happen in same millis in test and method is strict less than            
             //list, all.  
-            List<AuditLogEntryOutputDto> auditLogList = storage.getAuditLogListAll(time);
+            List<AuditLogEntryOutputDto> auditLogList = storage.getAuditLogOlderThanModifiedTimeListAll(time);
             assertEquals(1,auditLogList.size());
-
+            
             //list DR_PRODUCTION_ID 
-            auditLogList = storage.getAuditLogListByType(time,ObjectTypeEnumDto.DR_PRODUCTION_ID);
+            auditLogList = storage.getAuditLogOlderThanModifiedTimeListByType(time,ObjectTypeEnumDto.DR_PRODUCTION_ID);
             assertEquals(1,auditLogList.size());
 
             //list LICENSE (no rows)
-            auditLogList = storage.getAuditLogListByType(time,ObjectTypeEnumDto.LICENSE);
+            auditLogList = storage.getAuditLogOlderThanModifiedTimeListByType(time,ObjectTypeEnumDto.LICENSE);
             assertEquals(0,auditLogList.size());
         }
     }   

--- a/src/test/java/dk/kb/license/storage/AuditLogModuleStorageTest.java
+++ b/src/test/java/dk/kb/license/storage/AuditLogModuleStorageTest.java
@@ -96,6 +96,18 @@ public class AuditLogModuleStorageTest extends UnitTestUtil {
             assertEquals(changeComment, auditFromStorage.getChangeComment());
             assertEquals(textBefore, auditFromStorage.getTextBefore());
             assertEquals(textAfter, auditFromStorage.getTextAfter());
+            
+            //list, all
+            ArrayList<AuditLogEntryOutputDto> auditLogList = storage.getAuditLogList(System.currentTimeMillis(), null);
+            assertEquals(1,auditLogList.size());
+            
+            //list DR_PRODUCTION_ID 
+            auditLogList = storage.getAuditLogList(System.currentTimeMillis(),ObjectTypeEnumDto.DR_PRODUCTION_ID);
+            assertEquals(1,auditLogList.size());
+            
+            //list LICENSE (no rows)
+            auditLogList = storage.getAuditLogList(System.currentTimeMillis(),ObjectTypeEnumDto.LICENSE);
+            assertEquals(0,auditLogList.size());            
         }
     }
 }


### PR DESCRIPTION
Merge to master. 
New API method (/audit/auditEntries) to list AuditLogEntries by modifiedTime and ObjectTypeEnum.

I also renamed all the static column names for the table also. No need for the prefix after AuditLog was moved into its own Storage class.