### PR TITLE
fix: remove `'` from endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - New API method (/audit/auditEntries) to list AuditLogEntries by modifiedTime and ObjectTypeEnum.
 
+### Fixed
+- Removed `'` from `/audit/auditEntries` in `ds-license-openapi_v1.yaml` file.
+
 ## [4.0.3](https://github.com/kb-dk/ds-license/releases/tag/ds-license-4.0.3) 2026-02-16
 
 ### Changed

--- a/src/main/openapi/ds-license-openapi_v1.yaml
+++ b/src/main/openapi/ds-license-openapi_v1.yaml
@@ -519,7 +519,7 @@ paths:
                   $ref: '#/components/schemas/GroupType'
 
   # Audit  
-  /audit/auditEntries':
+  /audit/auditEntries:
     get:
       tags:
         - 'DsAudit'


### PR DESCRIPTION
Removed `'` from `/audit/auditEntries` in `ds-license-openapi_v1.yaml` file.