### PR TITLE
DRA-2708-minimum-client-jar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 -  Changed 'og' -> '&' in holdback category names
+-  Create minimum client jar. Cross module dependencies uses this new jar instead of the full classes jar.
 
 ### Added
 - New API method (/audit/auditEntries) to list AuditLogEntries by modifiedTime and ObjectTypeEnum.

--- a/pom.xml
+++ b/pom.xml
@@ -234,21 +234,20 @@
         <dependency>
             <groupId>dk.kb.util</groupId>
             <artifactId>kb-util</artifactId>
-        </dependency>
-        <!-- Client for ds-storage This will also require the org.openapitools dependency-->
+        </dependency>        
         <dependency>
             <groupId>dk.kb.storage</groupId>
             <artifactId>ds-storage</artifactId>
             <version>100.0.0-SNAPSHOT</version>
             <type>jar</type>
-            <classifier>classes</classifier>
+            <classifier>api</classifier>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>
                     <artifactId>*</artifactId>
                 </exclusion>
             </exclusions>
-        </dependency>
+       </dependency>
         <dependency>
             <groupId>jakarta.servlet</groupId>
             <artifactId>jakarta.servlet-api</artifactId>
@@ -630,9 +629,9 @@
                             <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
                         </manifest>
                     </archive>
-
-                    <!-- Generate a JAR with client classes and openapi-YAML for easy use by other services -->
-                    <attachClasses>true</attachClasses>
+                 
+                   <!-- Generation of API jar is done seperate plugin and only contains DTOs and client class -->                    
+                   <!-- <attachClasses>true</attachClasses> --> 
 
                     <!--Enable maven filtering for the web.xml-->
                     <filteringDeploymentDescriptors>true</filteringDeploymentDescriptors>
@@ -655,6 +654,27 @@
                         </resource>
                     </webResources>
                 </configuration>
+            </plugin>
+
+            <plugin>
+               <groupId>org.apache.maven.plugins</groupId>
+               <artifactId>maven-jar-plugin</artifactId>            
+               <executions>
+                   <execution>
+                   <id>build-specific-jar</id>
+                   <phase>package</phase>
+                   <goals>
+                       <goal>jar</goal>
+                   </goals>
+                  <configuration>                
+                      <classifier>api</classifier>
+                      <includes>                       
+                          <include>dk/kb/license/model/**</include>
+                          <include>dk/kb/license/util/DsLicenseClient*</include>                                            
+                      </includes>
+                 </configuration>
+                 </execution>
+              </executions>
             </plugin>
 
             <!-- Used only for mvn jetty:run jetty:run-war -->


### PR DESCRIPTION
Build new minimum client-jar with DTO's and client class only. Use maven jar plugin. New classifier is 'api'.
Remove building old jar for all classes. Cross module dependencies use the new minimum api jar.